### PR TITLE
MAINT: Add coordinate/satellite inheritance on 0.3.x

### DIFF
--- a/celest/encounter/_window_utils.py
+++ b/celest/encounter/_window_utils.py
@@ -6,7 +6,6 @@ viable encounters.
 
 from celest.encounter._encounter_math_utils import _analytical_encounter_ind
 from celest.satellite.coordinate import Coordinate
-from celest.satellite.time import Time
 from typing import Any, Literal
 from jplephem.spk import SPK
 import numpy as np
@@ -37,7 +36,7 @@ def _sun_itrs(julian: np.ndarray) -> np.ndarray:
 
     SPK.close(kernal)
 
-    sun_itrs = Coordinate(e2sun, "gcrs", Time(julian)).itrs()
+    sun_itrs = Coordinate(e2sun, "gcrs", julian).itrs()
 
     return sun_itrs
 
@@ -91,12 +90,12 @@ def _window_encounter_ind(satellite: Any, location: Any, ang: float, form:
         Array containing indices defining viable satellite encounter positions.
     """
 
-    sat_itrs = satellite.position.itrs()
-    time_data = satellite.time.julian()
+    sat_itrs = satellite.itrs()
+    time_data = satellite._julian
 
     ground_GEO = [location.lat, location.lon]
     ground_GEO = np.repeat(np.array([ground_GEO]), time_data.size, axis=0)
-    gnd_itrs = Coordinate(ground_GEO, "geo", Time(time_data)).itrs()
+    gnd_itrs = Coordinate(ground_GEO, "geo", time_data).itrs()
 
     enc_params = [sat_itrs, gnd_itrs, ang, form]
     analytical_ind = _analytical_encounter_ind(*enc_params)

--- a/celest/encounter/windows.py
+++ b/celest/encounter/windows.py
@@ -83,33 +83,32 @@ def generate(satellite: Any, location: Any, enc: Literal["image", "data link"],
     if factor > 1:
 
         if ang_type:
-            off_nadir = satellite.position.off_nadir(location)
+            off_nadir = satellite.off_nadir(location)
             ind = np.where(off_nadir < ang)[0]
 
         elif not ang_type:
-            alt, _ = satellite.position.horizontal(location)
+            alt, _ = satellite.horizontal(location)
             ind = np.where(alt > ang)[0]
 
         ind = np.split(ind, np.where(np.diff(ind) != 1)[0] + 1)
         ind = np.array(ind, dtype=object)
 
-        julian_interp = _interpolate(satellite.time.julian(), factor, 2, ind)
-        eci_interp = _interpolate(satellite.position.gcrs(), factor, 2, ind)
+        julian_interp = _interpolate(satellite._julian, factor, 2, ind)
+        eci_interp = _interpolate(satellite.gcrs(), factor, 2, ind)
 
-        satellite.position._GCRS = eci_interp
-        satellite.position._ITRS = None
-        satellite.position._GEO = None
-        satellite.position.length = eci_interp.shape[0]
-        satellite.position.time._julian = julian_interp
-        satellite.position.time._length = julian_interp.size
-        satellite.time = satellite.position.time
+        satellite._GCRS = eci_interp
+        satellite._ITRS = None
+        satellite._GEO = None
+        satellite.length = eci_interp.shape[0]
+        satellite._julian = julian_interp
+        satellite._length = julian_interp.size
 
     enc_ind = _window_encounter_ind(satellite, location, ang, ang_type, sca, lighting)
 
     window_ind = np.split(enc_ind, np.where(np.diff(enc_ind) != 1)[0] + 1)
     window_ind = np.array(window_ind, dtype=object)
 
-    times = satellite.time.julian()
+    times = satellite._julian
 
     if window_ind.size != 0:
 

--- a/celest/satellite/nutation_precession.py
+++ b/celest/satellite/nutation_precession.py
@@ -8,7 +8,6 @@ effects into GCRS and ITRS coordinate conversions.
 from celest.satellite._astronomical_quantities import (
     mean_obliquity, nutation_components, precession_angles
 )
-from typing import Tuple
 import numpy as np
 
 

--- a/celest/satellite/time.py
+++ b/celest/satellite/time.py
@@ -57,12 +57,12 @@ class Time(object):
         """Initialize attributes."""
 
         self._julian = julian + offset
-        self._length = self._julian.size
+        self.length = self._julian.size
 
     def __len__(self):
         """Return data size."""
 
-        return self._length
+        return self.length
 
     def true_solar_time(self, longitude: np.ndarray) -> np.ndarray:
         """Return the true solar time (TTs) in hours and decimals.

--- a/tests/test_encounter/test_encounter_math_utils.py
+++ b/tests/test_encounter/test_encounter_math_utils.py
@@ -4,7 +4,6 @@
 from celest.encounter.groundposition import GroundPosition
 from celest.encounter._encounter_math_utils import _analytical_encounter_ind
 from celest.satellite.coordinate import Coordinate
-from celest.satellite.time import Time
 from unittest import TestCase
 import numpy as np
 import unittest
@@ -18,11 +17,11 @@ class TestEncounterMathUtils(TestCase):
         fname = "tests/test_data/coordinate_validation_set.txt"
         data = np.loadtxt(fname=fname, delimiter="\t", skiprows=1)
 
-        times = data[:, 0]
-        itrs = data[:, 10:]
+        self.times = data[:, 0]
+        self.itrs = data[:, 10:]
 
-        self.timeData = Time(times, 2430000)
-        self.coor = Coordinate(itrs, "itrs", self.timeData)
+        self.offset = 2430000
+        self.coor = Coordinate(self.itrs, "itrs", self.times, self.offset)
         self.length = data.shape[0]
 
     def test_anaytical_encounter_ind(self):

--- a/tests/test_encounter/test_windows.py
+++ b/tests/test_encounter/test_windows.py
@@ -5,9 +5,7 @@ from celest.encounter.groundposition import GroundPosition
 from celest.encounter.windows import generate
 from celest.encounter._window_handling import Window, Windows
 from celest.encounter._window_utils import _window_encounter_ind
-from celest.satellite.coordinate import Coordinate
 from celest.satellite.satellite import Satellite
-from celest.satellite.time import Time
 from unittest import TestCase
 import numpy as np
 import unittest
@@ -22,10 +20,7 @@ class TestEncounter(TestCase):
         data = np.loadtxt(fname=fname, delimiter="\t", skiprows=1)
         times, itrs = data[:, 0], data[:, 10:]
 
-        timeData = Time(times, 2430000)
-        coor = Coordinate(itrs, "itrs", timeData)
-
-        self.finch = Satellite(coor)
+        self.finch = Satellite(itrs, "itrs", times, 2430000)
 
     def test_windows(self):
         """Test `Encounter.windows.generate.`"""
@@ -39,7 +34,7 @@ class TestEncounter(TestCase):
         indices = np.split(indices, np.where(np.diff(indices) != 1)[0] + 1)
 
         val_windows = Windows()
-        time = self.finch.time.julian()
+        time = self.finch._julian
         for reg in indices:
                 
             start = time[reg[0]]
@@ -61,7 +56,7 @@ class TestEncounter(TestCase):
         indices = np.split(indices, np.where(np.diff(indices) != 1)[0] + 1)
 
         val_windows = Windows()
-        time = self.finch.time.julian()
+        time = self.finch._julian
         for reg in indices:
                 
             start = time[reg[0]]
@@ -82,7 +77,7 @@ class TestEncounter(TestCase):
         indices = np.split(indices, np.where(np.diff(indices) != 1)[0] + 1)
 
         val_windows = Windows()
-        time = self.finch.time.julian()
+        time = self.finch._julian
         for reg in indices:
                 
             start = time[reg[0]]
@@ -104,7 +99,7 @@ class TestEncounter(TestCase):
         indices = np.split(indices, np.where(np.diff(indices) != 1)[0] + 1)
 
         val_windows = Windows()
-        time = self.finch.time.julian()
+        time = self.finch._julian
         for reg in indices:
                 
             start = time[reg[0]]

--- a/tests/test_satellite/test_coordinate.py
+++ b/tests/test_satellite/test_coordinate.py
@@ -3,7 +3,6 @@
 
 from celest.encounter.groundposition import GroundPosition
 from celest.satellite.coordinate import Coordinate
-from celest.satellite.time import Time
 from unittest import TestCase
 import numpy as np
 import unittest

--- a/tests/test_satellite/test_satellite.py
+++ b/tests/test_satellite/test_satellite.py
@@ -3,9 +3,7 @@
 
 from celest.encounter.groundposition import GroundPosition
 from celest.encounter._window_handling import Window, Windows
-from celest.satellite.coordinate import Coordinate
 from celest.satellite.satellite import Satellite
-from celest.satellite.time import Time
 from unittest import TestCase
 import numpy as np
 import unittest

--- a/tests/test_satellite/test_satellite.py
+++ b/tests/test_satellite/test_satellite.py
@@ -22,17 +22,18 @@ class TestSatellite(TestCase):
         self.times = data[:, 0]
         self.ITRS = data[:, 10:]
 
-        self.timeData = Time(self.times, 2430000)
-        self.coor = Coordinate(self.ITRS, "itrs", self.timeData)
+        # self.timeData = Time(self.times, 2430000)
+        # self.coor = Coordinate(self.ITRS, "itrs", self.timeData)
 
-        self.finch = Satellite(self.coor)
+        self.offset = 2430000
+        self.finch = Satellite(self.ITRS, "itrs", self.times, self.offset)
 
     def test_interpolate(self):
         """Test `Satellite.interpolate`."""
 
         location = GroundPosition(0, 0)
 
-        window = Window(None, location, self.times[100] + 2430000, self.times[150] + 2430000, None, None, None, None)
+        window = Window(None, location, self.times[100] + self.offset, self.times[150] + self.offset, None, None, None, None)
         window_list = Windows()
         window_list._add_window(window)
 
@@ -60,13 +61,13 @@ class TestSatellite(TestCase):
         load_gcrs = data[:, 8:11]
         load_itrs = data[:, 11:]
 
-        julian = self.finch.time.julian()
-        ut1 = self.finch.time.ut1()
-        gmst = self.finch.time.gmst()
-        gast = self.finch.time.gast()
-        geo = self.finch.position.geo()
-        gcrs = self.finch.position.gcrs()
-        itrs = self.finch.position.itrs()
+        julian = self.finch.julian()
+        ut1 = self.finch.ut1()
+        gmst = self.finch.gmst()
+        gast = self.finch.gast()
+        geo = self.finch.geo()
+        gcrs = self.finch.gcrs()
+        itrs = self.finch.itrs()
 
         self.assertTrue(np.array_equal(load_julian, julian))
         self.assertTrue(np.array_equal(load_ut1, ut1))


### PR DESCRIPTION
The current structure of the `Coordinate` and `Satellite` classes are clumsy to instantiate with the need to initialize the `Time` and/or `Coordinate` classes beforehand. Appealing to inheritance, the input arguments were modified to include simpler data types and reduce difficulty in `Time` access from the `Coordinate` class.
