### PR TITLE
Merge VTW-OW-framework with develop-v0.4.0.

### DIFF
--- a/celest/encounter/_window_handling.py
+++ b/celest/encounter/_window_handling.py
@@ -1,100 +1,60 @@
 
 
-from celest.encounter.groundposition import GroundPosition
 from typing import Any
 import numpy as np
 import pandas as pd
 
 
-class Window:
-    """Window(satellite, location, start, end, enc, ang, lighting)
+class VTW:
+    """VTW(rise_time, set_time)
 
-    Encounter information.
+    Visible window time.
+
+    A visibile window time describes an event where the satellite is in line of
+    sight of the ground station within an elevation constraint.
 
     Parameters
     ----------
-    satellite : Satellite
-        Satellite for ground location encounter.
-    location : GroundPosition
-        Ground location for satellite encounter.
-    start, end: float
-        Window start and end times in J2000 Julian.
-    enc : {"data link", "image"}
-        Encounter type.
-    ang : float
-        Encounter constraint angle.
-    lighting : {-1, 0, 1}
-        Lighting constraint for night only, all time, or day only encounters.
+    rise_time : float
+        Rise time of the visible time window in julian days.
+    set_time : float
+        Set time of the visible time window in julian days.
 
     Attributes
     ----------
-    satellite : Satellite
-        Satellite for ground location encounter.
-    coor : tuple
-        Ground location (lat, lon) coordinates.
-    start, end : float
-        Window start and end times in J2000 Julian.
-    dt : float
-        Window duration in seconds.
-    type : {"data link", "image"}
-        Encounter type.
-    ang : float
-        Encounter constraint angle in degrees.
-    lighting : {-1, 0, 1}
-        Lighting constraint for night only, all time, or day only encounters.
+    rise_time : float
+        Rise time of the visible time window in julian days.
+    set_time : float
+        Set time of the visible time window in julian days.
+    duration : float
+        Duration of the visible time window in seconds.
     """
 
-    def __init__(self, satellite, location, start, end, enc, ang, lighting) -> None:
+    def __init__(self, rise_time, set_time) -> None:
 
-        self.satellite = satellite
-        self.coor = (location.lat, location.lon)
-
-        self.start = start
-        self.end = end
-        self.duration = 86400 * (end - start)
-
-        self.type = enc
-        self.ang = ang
-        self.lighting = lighting
+        self.rise_time = rise_time
+        self.set_time = set_time
+        self.duration = 86400 * (set_time - rise_time)
 
     def __str__(self) -> str:
 
-        str_1 = str(self.coor) + " "
-        str_2 = self.type + " "
-        str_3 = "ang:" + str(self.ang) + " "
-        str_4 = "lighting:" + str(self.lighting) + " "
-        str_5 = "start:" + str(self.start) + " "
-        str_6 = "end:" + str(self.end)
-
-        str_final = str_1 + str_2 + str_3 + str_4 + str_5 + str_6
-
-        return str_final
+        return f"Rise: {self.rise_time}, Set:{self.set_time}, Duration: {self.duration}s"
 
     def copy(self) -> Any:
-        """Return `Window` copy.
+        """Return `VTW` copy.
 
         Returns
         -------
-        Window
+        VTW
 
         Examples
         --------
-        Let `window_old` be a `Window` object.
+        Let `VTW_old` be a `VTW` object.
 
-        >>> window_new = window_old.copy()
+        >>> VTW_new = VTW_old.copy()
         """
 
-        sat = self.satellite
-        gnd = GroundPosition(self.coor[0], self.coor[1])
-        start = self.start
-        end = self.end
-        enc = self.type
-        ang = self.ang
-        lighting = self.lighting
-
-        return_window = Window(sat, gnd, start, end, enc, ang, lighting)
-
-        return return_window
+        return VTW(self.rise_time, self.set_time)
 
 
 class Windows:

--- a/celest/encounter/_window_handling.py
+++ b/celest/encounter/_window_handling.py
@@ -1,6 +1,6 @@
 
 
-from typing import Any
+from typing import Any, Literal
 import numpy as np
 import pandas as pd
 
@@ -58,7 +58,7 @@ class VTW:
 
 
 class OW:
-    """OW(start, duration, location, quality, deadline)
+    """OW(start_time, duration, location, quality, deadline)
 
     Observation window.
 
@@ -67,7 +67,7 @@ class OW:
 
     Parameters
     ----------
-    start : float
+    start_time : float
         Start time of the observing window in julian days.
     duration : float
         Duration of the observing window in seconds.
@@ -92,14 +92,14 @@ class OW:
         Deadline of the observing window in julian days.
     """
 
-    def __init__(self, start, duration, location, quality, deadline) -> None:
+    def __init__(self, start_time, duration, location, quality, deadline) -> None:
 
-        self.start = start
+        self.start_time = start_time
         self.duration = duration
         self.location = location
         self.quality = quality
         self.deadline = deadline
-    
+
     def __str__(self) -> str:
 
         return f"Location: {self.location.coor}, Start: {self.rise_time}, Duration:{self.set_time}s"
@@ -118,14 +118,13 @@ class OW:
         >>> OW_new = OW_old.copy()
         """
 
-        return OW(self.start, self.duration, self.location, self.quality, self.deadline)
+        return OW(self.start_time, self.duration, self.location, self.quality, self.deadline)
 
 
-class Windows:
-    """Data structure to hold `Window` objects.
+class WindowHandler:
+    """WindowHandler()
 
-    This class is designed to hold encounter information and facilitate
-    user-data interactions.
+    Data structure to hold `VTW` or `OW` objects.
     """
 
     def __init__(self) -> None:
@@ -148,14 +147,13 @@ class Windows:
 
             return self.windows[index]
 
-    def __getitem__(self, key) -> Window:
+    def __getitem__(self, key) -> Literal[VTW, OW]:
         """Return window closest to key time.
 
-        This method allows for window indexing. If a scalar index is provided,
-        the window with the closest start time will be returned. If the index
-        is a range, all windows that have start times within the range will be
-        returned. If the index is a tuple, then all the windows with start
-        times closes to each tuple entry will be returned.
+        For a scalar index, the window with the closest start time will be
+        returned. For a range index, all windows with start times within the
+        range will be returned. For a tuple index, all the windows with start
+        times closest to each tuple entry will be returned.
         """
 
         inds = self.windows.index.to_numpy()
@@ -185,88 +183,53 @@ class Windows:
 
         return len(self.windows)
 
+    def _window_start(self, window) -> float:
+
+        return window.rise_time if isinstance(window, VTW) else window.start_time
+
     def _add_window(self, window) -> None:
         """Add new window to data base.
 
         Parameters
         ----------
-        window : Window
-
-        Notes
-        -----
-        This method adds a new window to the data base by appending it to the
-        internal Pandas Series object indexed by the window's start time.
+        window : VTW or OW
         """
 
-        temp_series = pd.Series(window, index=[window.start])
+        temp_series = pd.Series(window, index=[self._window_start(window)])
         self.windows = pd.concat([self.windows, temp_series])
         self.windows.sort_index(inplace=True)
 
-    def stats(self) -> pd.DataFrame:
-        """Return enocunter statistics.
+    def get_window(self, julian) -> Literal[VTW, OW]:
+        """Return window closest to julian time.
 
-        This method returns statistics on the stored encounters. The statistics
-        include the 5th, 50th, and 95th percentile of encounter durations and
-        enocounter frequency.
+        Parameters
+        ----------
+        julian : float
+            Julian time in julian days.
 
-        Return
-        ------
-        DataFrame
-            Data base of encounter statistics.
-
-        Examples
-        --------
-        Assuming `toronto_img` is a `Windows` object returned from the windows
-        generation function.
-
-        >>> stats = toronto_img.stats()
-        >>> print(stats)
-                                       (45, -73), image
-        Q5 Duration (s)                      108.468446
-        Q50 Duration (s)                     167.687443
-        Q75 Duration (s)                     177.506299
-        Encounter Frequency (per day)          1.340795
+        Returns
+        -------
+        VTW or OW
         """
 
-        if len(self.windows) == 0:
-            return None
+        return self[julian]
 
-        enc_dict = {}
-        start_times = np.empty((0,))
-        end_times = np.empty((0,))
+    def get_windows_in_range(self, start, end) -> Literal[VTW, OW]:
+        """Return all windows with start times within the range.
 
-        for window in self.windows:
+        Parameters
+        ----------
+        start : float
+            Start time of the range in julian days.
+        end : float
+            End time of the range in julian days.
 
-            if (window.coor, window.type) not in enc_dict.keys():
-                enc_dict[window.coor, window.type] = np.array(
-                    [window.duration])
-            else:
-                arr = enc_dict[window.coor, window.type]
-                new_arr = np.append(arr, window.duration)
-                enc_dict[window.coor, window.type] = new_arr
+        Returns
+        -------
+        VTW or OW
+        """
 
-            start_times = np.append(start_times, window.start)
-            end_times = np.append(end_times, window.end)
-
-        out_data = {}
-        num_days = np.max(end_times) - np.min(start_times)
-
-        for key in enc_dict.keys():
-
-            dt_data = enc_dict[key]
-            enc_str = f"{key[0]}, {key[1]}"
-            qs = np.percentile(dt_data, [5, 50, 75])
-            freq = len(dt_data) / num_days
-
-            out_data[enc_str] = pd.Series([qs[0], qs[1], qs[2], freq])
-
-        df = pd.DataFrame.from_dict(out_data)
-        df.index = ["Q5 Duration (s)",
-                    "Q50 Duration (s)",
-                    "Q75 Duration (s)",
-                    "Encounter Frequency (per day)"]
-
-        return df
+        return self[start:end]
 
     def to_numpy(self) -> np.ndarray:
         """Return windows within a NumPy array.
@@ -291,13 +254,112 @@ class Windows:
 
         return self.windows.to_numpy()
 
+
+class VTWHandler(WindowHandler):
+    """VTWHandler()
+
+    Data structure to hold `VTW` objects.
+    """
+
+    def __init__(self) -> None:
+
+        super().__init__()
+
+    def stats(self) -> pd.DataFrame:
+        """Return visible time window statistics.
+
+        This method returns statistics on the visible time windows, including
+        the 5th, 50th, and 95th percentile of encounter durations and
+        enocounter frequency.
+
+        Return
+        ------
+        DataFrame
+            Data base of encounter statistics.
+
+        Examples
+        --------
+        Assuming `toronto_img` is a `VTWHandler` object returned from the
+        windows generation function.
+
+        >>> stats = toronto_img.stats()
+        >>> print(stats)
+                                              Statistic
+        Minimum Duration (s)                        0.0
+        Q5 Duration (s)                      108.468446
+        Q50 Duration (s)                     167.687443
+        Q75 Duration (s)                     177.506299
+        Maximum Duration (s)                      524.0
+        Encounter Frequency (per day)          1.340795
+        """
+
+        if len(self.windows) == 0:
+            return None
+
+        duration = []
+        rise_times = []
+        set_times = []
+
+        for window in self.windows:
+            duration.append(window.duration)
+            rise_times.append(window.rise_time)
+            set_times.append(window.set_time)
+
+        data = {}
+        data['Min Duration (s)'] = np.min(duration)
+        data['Q5 Duration (s)'] = np.percentile(duration, 5)
+        data['Q50 Duration (s)'] = np.percentile(duration, 50)
+        data['Q95 Duration (s)'] = np.percentile(duration, 95)
+        data['Max Duration (s)'] = np.max(duration)
+        data['Encounter Frequency (per day)'] = len(self) / (np.max(set_times) - np.min(rise_times))
+
+        df = pd.DataFrame(pd.Series(data), columns=["Statistic"])
+
+        return df
+
     def save(self, fname, delimiter) -> None:
-        """Save encounter information.
+        """Save visible time window information.
 
         Parameters
         ----------
         fname : str
-            File name to save encounter information to.
+            File name to save encounter information under.
+        delimiter : {",", "\\t"}
+            String or character separating columns.
+        """
+
+        np_data = self.to_numpy()
+
+        out_data = np.empty(shape=(np_data.shape[0] + 1, 3), dtype="<U25")
+        out_data[0, :] = ["Rise Time (JD2000)", "Set Time (JD2000)", "Duration (s)"]
+
+        for i, window in enumerate(np_data):
+
+            out_data[i + 1, 0] = window.rise_time
+            out_data[i + 1, 1] = window.set_time
+            out_data[i + 1, 2] = window.duration
+
+        np.savetxt(fname, out_data, delimiter=delimiter,
+                   fmt="%s,%s,%s")
+
+
+class OWHandler(WindowHandler):
+    """OWHandler()
+
+    Data structure to hold `OW` objects.
+    """
+
+    def __init__(self) -> None:
+
+        super().__init__()
+
+    def save(self, fname, delimiter) -> None:
+        """Save observation window information.
+
+        Parameters
+        ----------
+        fname : str
+            File name to save encounter information under.
         delimiter : {",", "\\t"}
             String or character separating columns.
         """
@@ -306,22 +368,22 @@ class Windows:
 
         out_data = np.empty(shape=(np_data.shape[0] + 1, 6), dtype="<U25")
         out_data[0, :] = [
-            "latitude (deg)",
-            "longitude (deg)",
-            "start (jul)",
-            "end (jul)",
-            "duration (sec)",
-            "type"
+            "Latitude (deg)",
+            "Longitude (deg)",
+            "Start Time (JD2000)",
+            "Duration (s)",
+            "Quality (1-10)",
+            "Deadline (JD2000)"
         ]
 
         for i, window in enumerate(np_data):
 
-            out_data[i + 1, 0] = window.coor[0]
-            out_data[i + 1, 1] = window.coor[1]
-            out_data[i + 1, 2] = window.start
-            out_data[i + 1, 3] = window.end
-            out_data[i + 1, 4] = window.duration
-            out_data[i + 1, 5] = window.type
+            out_data[i + 1, 0] = window.location.lat
+            out_data[i + 1, 1] = window.location.lon
+            out_data[i + 1, 2] = window.start_time
+            out_data[i + 1, 3] = window.duration
+            out_data[i + 1, 4] = window.quality
+            out_data[i + 1, 5] = window.deadline
 
         np.savetxt(fname, out_data, delimiter=delimiter,
                    fmt="%s,%s,%s,%s,%s,%s")

--- a/celest/encounter/_window_handling.py
+++ b/celest/encounter/_window_handling.py
@@ -187,7 +187,7 @@ class WindowHandler:
 
         return window.rise_time if isinstance(window, VTW) else window.start_time
 
-    def _add_window(self, window) -> None:
+    def _add_window_base(self, window) -> None:
         """Add new window to data base.
 
         Parameters
@@ -264,6 +264,19 @@ class VTWHandler(WindowHandler):
     def __init__(self) -> None:
 
         super().__init__()
+    
+    def _add_window(self, window) -> None:
+        """Add new window to data base.
+
+        Parameters
+        ----------
+        window : VTW
+        """
+
+        if isinstance(window, VTW):
+            self._add_window_base(window)
+        else:
+            raise TypeError("Expected VTW object.")
 
     def stats(self) -> pd.DataFrame:
         """Return visible time window statistics.
@@ -352,6 +365,19 @@ class OWHandler(WindowHandler):
     def __init__(self) -> None:
 
         super().__init__()
+    
+    def _add_window(self, window) -> None:
+        """Add new window to data base.
+
+        Parameters
+        ----------
+        window : OW
+        """
+
+        if isinstance(window, OW):
+            self._add_window_base(window)
+        else:
+            raise TypeError("Expected OW object.")
 
     def save(self, fname, delimiter) -> None:
         """Save observation window information.

--- a/celest/encounter/_window_handling.py
+++ b/celest/encounter/_window_handling.py
@@ -57,6 +57,70 @@ class VTW:
         return VTW(self.rise_time, self.set_time)
 
 
+class OW:
+    """OW(start, duration, location, quality, deadline)
+
+    Observation window.
+
+    The observation window describes a selected time window in which the
+    satellite-to-ground encounter is to be executed.
+
+    Parameters
+    ----------
+    start : float
+        Start time of the observing window in julian days.
+    duration : float
+        Duration of the observing window in seconds.
+    location : GroundPosition
+        Location of the satellite-ground encounter.
+    quality : float
+        Quality of the observing window.
+    deadline : float
+        Deadline of the observing window in julian days.
+
+    Attributes
+    ----------
+    start : float
+        Start time of the observing window in julian days.
+    duration : float
+        Duration of the observing window in seconds.
+    location : GroundPosition
+        Location of the satellite-ground encounter.
+    quality : float
+        Quality of the observing window.
+    deadline : float
+        Deadline of the observing window in julian days.
+    """
+
+    def __init__(self, start, duration, location, quality, deadline) -> None:
+
+        self.start = start
+        self.duration = duration
+        self.location = location
+        self.quality = quality
+        self.deadline = deadline
+    
+    def __str__(self) -> str:
+
+        return f"Location: {self.location.coor}, Start: {self.rise_time}, Duration:{self.set_time}s"
+
+    def copy(self) -> Any:
+        """Return `OW` copy.
+
+        Returns
+        -------
+        OW
+
+        Examples
+        --------
+        Let `OW_old` be a `OW` object.
+
+        >>> OW_new = OW_old.copy()
+        """
+
+        return OW(self.start, self.duration, self.location, self.quality, self.deadline)
+
+
 class Windows:
     """Data structure to hold `Window` objects.
 

--- a/celest/encounter/windows.py
+++ b/celest/encounter/windows.py
@@ -168,7 +168,7 @@ def generate_vtw(satellite, location, vis_threshold, lighting=0, tol=1e-5) -> VT
 
     if vis_threshold < 0 or vis_threshold >= 90:
         raise ValueError("Visibility threshold should be in the range [0, 90).")
-    
+
     if lighting not in (-1, 0, 1):
         raise ValueError("Valid ighting conditions include -1, 0, and 1.")
 

--- a/docs/source/guide/quickstart.rst
+++ b/docs/source/guide/quickstart.rst
@@ -42,8 +42,8 @@ to determine encounter opportunities.
    toronto = GroundPosition(latitude=43.65, longitude=-79.38, height=0.076)
 
    # Generate ground location windows.
-   toronto_IMG_windows = windows.generate(satellite=satellite, location=toronto, enc="image", ang=30, lighting=1)
-   toronto_GL_windows = windows.generate(satellite=satellite, location=toronto, enc="data link", ang=10, lighting=0)
+   toronto_IMG_windows = windows.generate_vtw(satellite=satellite, location=toronto, vis_threshold=10, lighting=1)
+   toronto_GL_windows = windows.generate_vtw(satellite=satellite, location=toronto, vis_threshold=10, lighting=0)
 
    # Save satellite encounter windows.
    toronto_IMG_windows.save(fname="toronto_IMG_windows.csv", delimiter=",")

--- a/docs/source/guide/tutorials.rst
+++ b/docs/source/guide/tutorials.rst
@@ -132,32 +132,22 @@ only one :class:`GroundPosition` object is required.
    toronto = GroundPosition(latitude=43.6532, longitude=-79.3832, height=0.076)
    saskatoon = GroundPosition(latitude=52.1579, longitude=-106.6702, height=0.482)
 
-We are now ready to generate windows. The :py:func:`windows.generate` function
+We are now ready to generate windows. The :py:func:`windows.generate_vtw` function
 takes a satellite and ground location as an input and will populate a
-:class:`Windows` object with visible window times for the encounter
-defined by the `enc` and `ang` keywords.
+:class:`VTWHandling` object with visible time windows defined by the
+`vis_threshold` and `lighting` keywords.
 
-There are two encounter types that Celest currently supports: (1) imaging
-encounters where the satellite is in view of the ground location, and (2) data
-transmission encounters where the ground location is in view of the satellite.
-The `enc` keyword specifies the type of encounter as either and imaging
-(`enc="image"`) or data transmission (`enc="data link"`) type.
 
-The `ang` keyword defines the constraint angle that borders a
-viable/non-viable encounter region. The constraint angle type used for imaging
-encounters is the off-nadir angle measured in increasing degrees from the
-satellite's nadir to the ground location. Transmission encounters use the
-elevation angle of the satellite as measured in increasing degrees above the
-horizon (as seen from the ground location).
-
-The lighting conditions can also be set. For example, to image only in the
-daylight, we can set `lighting=1`.
+The `vis_threshold` keyword defines the minimum satellite elevation angle as
+seen from the ground location that will allow for satellite-ground
+interactions. The `lighting` keyword allows us to specify the lighting
+conditions of the visible time windows.
 
 .. code-block::
 
    # Generate ground location windows.
-   toronto_IMG_windows = windows.generate(satellite=satellite, location=toronto, enc="image", ang=30, lighting=1)
-   toronto_GL_windows = windows.generate(satellite=satellite, location=toronto, enc="data link", ang=10, lighting=0)
+   toronto_IMG_windows = windows.generate_vtw(satellite=satellite, location=toronto, vis_threshold=10, lighting=1)
+   toronto_GL_windows = windows.generate_vtw(satellite=satellite, location=toronto, vis_threshold=10, lighting=0)
 
    # Save satellite encounter windows.
    toronto_IMG_windows.save(fname="toronto_IMG_windows.csv", delimiter=",")

--- a/docs/source/modules/encounter.rst
+++ b/docs/source/modules/encounter.rst
@@ -18,43 +18,49 @@ more complicated ellipsoid models based on the input geographical coordinates.
 Window Generation
 -----------------
 
-The window generation function produces all viable encounter opportunities of a
-specified type for a given satellite and ground location.
+The window generation function determines all visible time windows for a
+satellite and ground-location pair where the satellites elevation is
+greater than the visibility threshold.
 
-.. autofunction:: celest.encounter.windows.generate
+.. autofunction:: celest.encounter.windows.generate_vtw
    :noindex:
 
 Window Handling
 ---------------
 
-The :class:`Windows` class is the returned data structure from the
-:py:func:`windows.generate` function which holds all encounter opportunities as
-:class:`Window` objects and provides basic functionality to gain insight and
-access to the data. The following details these two classes.
+The :class:`VTWHandling` class is the data structure returned from the
+:py:func:`windows.generate_vtw` function which holds all visible time windows
+as :class:`VTW` objects and provides an interface to access the data. The
+following details these two classes.
 
-Windows
-~~~~~~~
+VTWHandling
+~~~~~~~~~~~
 
-The window data held within the :class:`Windows` class can be interfaced in two
-ways: indexing and iterating.
+The window data held within the :class:`VTWHandling` class can be interfaced in
+three ways: indexing, using access methods, and iterating.
 
-To provide meaningful interactions with the window data, the :class:`Windows`
-is indexed by Julian start times in the J2000 epoch. Although, the start times
-are typically unknown to the user. As a result, a unique indexing scheme was
-adopted by the class to provide data access that might be convenient in
-context. The window associated with the closest start time is returned when
-indexing using an integer or float value. Similarly, when indexing with a tuple
-of values, the unique windows related to the closest start time are returned.
-When two indices are both closest to the start time of a window, the window is
-only returned once. All windows with start times falling within the slice
-(inclusive) are returned if the index is a slice.
+To provide meaningful interactions with the window data, the
+:class:`VTWHandling` is indexed by Julian start times in the J2000 epoch.
+Although, the start times are typically unknown to the user. As a result, a
+unique indexing scheme was adopted by the class to provide data access that
+might be convenient in context. The window associated with the closest start
+time is returned when indexing using an integer or float value. Similarly,
+when indexing with a tuple of values, the unique windows related to the closest
+start time are returned. When two indices are both closest to the start time of
+a window, the window is only returned once. All windows with start times
+falling within the slice (inclusive) are returned if the index is a slice.
 
 This indexing scheme allows users to easily access the data in the
-:class:`Windows` class without prior knowledge of start times. It also
+:class:`VTWHandling` class without prior knowledge of start times. It also
 allows the user to determine the encounter closest to the desired time for
 scheduling purposes.
 
-Window data can also be accessed by iterating over the class.
+The window data can also be interfaced with using the :py:func:`get_window` and
+:py:func:`get_windows_in_range` methods. The first returns the window with the
+closes start time. The latter returns all windows with start times falling
+within the input range.
+
+Lastly, window data can be accessed by iterating over the class.
 
 Examples of object interactions are seen in the following example.
 
@@ -75,6 +81,14 @@ Examples of object interactions are seen in the following example.
    window_object = windows_object[2405796.5:2405796.7]
    # window_object is a list containing windows with the 2405795.5, 2405796.5 start times.
 
+   # Window accessed through the get_window method by the start time 2405796.5.
+   window_object = windows_object.get_window(2405796.5)
+   # window_object now contains the window starting at 2405796.5.
+
+   # Window accessed through the get_windows_in_range method using a start and end time.
+   window_object = windows_object.get_windows_in_range(2405796.5, 2405796.7)
+   # window_object is a list containing windows with the 2405795.5, 2405796.5 start times.
+
    # Window accessed by iterating over the class.
    for window_object in windows_object:
 
@@ -84,19 +98,19 @@ Examples of object interactions are seen in the following example.
       end = window_object.start
    
 
-.. autoclass:: celest.encounter._window_handling.Windows
+.. autoclass:: celest.encounter._window_handling.VTWHandling
    :members:
    :show-inheritance:
    :noindex:
 
-Window
-~~~~~~
+VTW
+~~~
 
-The :class:`Window` class is the data structure that holds all the information
+The :class:`VTW` class is the data structure that holds all the information
 regarding a specific encounter opportunity. The important information is held
 in a series of attributes.
 
-.. autoclass:: celest.encounter._window_handling.Window
+.. autoclass:: celest.encounter._window_handling.VTW
    :members:
    :show-inheritance:
    :noindex:

--- a/tests/test_encounter/test_window_handling.py
+++ b/tests/test_encounter/test_window_handling.py
@@ -62,11 +62,11 @@ class TestWindowHandler(TestCase):
         self.W4 = VTW(1324.3, 1325.3)
         self.W5 = VTW(1325, 1326.1)
 
-        self.windows._add_window(self.W1)
-        self.windows._add_window(self.W2)
-        self.windows._add_window(self.W3)
-        self.windows._add_window(self.W4)
-        self.windows._add_window(self.W5)
+        self.windows._add_window_base(self.W1)
+        self.windows._add_window_base(self.W2)
+        self.windows._add_window_base(self.W3)
+        self.windows._add_window_base(self.W4)
+        self.windows._add_window_base(self.W5)
 
     def test_getitem(self):
 
@@ -143,7 +143,6 @@ class TestVTWHandler(TestCase):
     def test_stats(self):
 
         stats = self.windows.stats()
-        print(stats)
         self.assertIsNotNone(stats)
 
     def test_save(self):

--- a/tests/test_encounter/test_window_handling.py
+++ b/tests/test_encounter/test_window_handling.py
@@ -1,73 +1,97 @@
 
 
 from celest.encounter.groundposition import GroundPosition
-from celest.encounter._window_handling import Window, Windows
+from celest.encounter._window_handling import VTW, OW, WindowHandler, VTWHandler, OWHandler
 from unittest import TestCase
 import numpy as np
 import unittest
+import os
 
 
-class TestWindow(TestCase):
+class TestVTW(TestCase):
 
     def setUp(self):
 
-        location = GroundPosition(43.6532, 79.3832)
-        self.window = Window("", location, 21282.4, 21282.5, "image", 30, 1)
+        rise_time = 21282.4
+        set_time = 21282.5
+
+        self.window = VTW(rise_time, set_time)
 
     def test_copy(self):
 
         wind_copy = self.window.copy()
 
-        self.assertTrue(self.window.satellite == wind_copy.satellite)
-        self.assertTrue(self.window.coor == wind_copy.coor)
-        self.assertTrue(self.window.type == wind_copy.type)
-        self.assertTrue(self.window.start == wind_copy.start)
-        self.assertTrue(self.window.end == wind_copy.end)
+        self.assertTrue(self.window.rise_time == wind_copy.rise_time)
+        self.assertTrue(self.window.set_time == wind_copy.set_time)
+        self.assertTrue(self.window.duration == wind_copy.duration)
 
 
-class TestWindows(TestCase):
+class TestOW(TestCase):
 
     def setUp(self):
 
-        location = GroundPosition(43.6532, 79.3832)
-        self.windows = Windows()
+        start_time = 21282.4
+        duration = 30
+        location = GroundPosition(43.6532, 79.3832, 0.076)
+        quality = 9
+        deadline = 21284.3
 
-        self.wind_one = Window("", location, 1319, 1319.2, "image", 30, 1)
-        self.wind_two = Window("", location, 1322.3, 1322.31, "data link", 10, -1)
-        self.wind_three = Window("", location, 1324, 1324.2, "image", 30, 1)
-        self.wind_four = Window("", location, 1324.3, 1325.3, "image", 30, 1)
-        self.wind_five = Window("", location, 1325, 1326.1, "image", 30, 1)
+        self.window = OW(start_time, duration, location, quality, deadline)
 
-        self.windows._add_window(self.wind_one)
-        self.windows._add_window(self.wind_two)
-        self.windows._add_window(self.wind_three)
-        self.windows._add_window(self.wind_four)
-        self.windows._add_window(self.wind_five)
+    def test_copy(self):
+
+        wind_copy = self.window.copy()
+
+        self.assertTrue(self.window.start_time == wind_copy.start_time)
+        self.assertTrue(self.window.duration == wind_copy.duration)
+        self.assertTrue(self.window.location.lat == wind_copy.location.lat)
+        self.assertTrue(self.window.location.lon == wind_copy.location.lon)
+        self.assertTrue(self.window.quality == wind_copy.quality)
+        self.assertTrue(self.window.deadline == wind_copy.deadline)
+
+
+class TestWindowHandler(TestCase):
+
+    def setUp(self):
+
+        self.windows = WindowHandler()
+
+        self.W1 = VTW(1319, 1319.2)
+        self.W2 = VTW(1322.3, 1322.31)
+        self.W3 = VTW(1324, 1324.2)
+        self.W4 = VTW(1324.3, 1325.3)
+        self.W5 = VTW(1325, 1326.1)
+
+        self.windows._add_window(self.W1)
+        self.windows._add_window(self.W2)
+        self.windows._add_window(self.W3)
+        self.windows._add_window(self.W4)
+        self.windows._add_window(self.W5)
 
     def test_getitem(self):
 
         # Test int/float indexing.
-        self.assertEqual(self.windows[1310], self.wind_one)
-        self.assertEqual(self.windows[1319], self.wind_one)
-        self.assertEqual(self.windows[1323], self.wind_two)
-        self.assertEqual(self.windows[1324.4], self.wind_four)
-        self.assertEqual(self.windows[1330], self.wind_five)
+        self.assertEqual(self.windows[1310], self.W1)
+        self.assertEqual(self.windows[1319], self.W1)
+        self.assertEqual(self.windows[1323], self.W2)
+        self.assertEqual(self.windows[1324.4], self.W4)
+        self.assertEqual(self.windows[1330], self.W5)
 
         # Test tuple indexing with unique mapping.
-        arr = [self.wind_two, self.wind_five]
+        arr = [self.W2, self.W5]
         val_wind = np.array(arr, dtype=object)
         self.assertTrue(np.array_equiv(self.windows[1322.5, 1325], val_wind))
 
         # Test tuple indexing without unique mapping.
-        self.assertEqual(self.windows[1323.5, 1324.1], self.wind_three)
+        self.assertEqual(self.windows[1323.5, 1324.1], self.W3)
 
         # Test slice indexing without boundaries cases.
-        arr = [self.wind_three, self.wind_four, self.wind_five]
+        arr = [self.W3, self.W4, self.W5]
         val_wind = np.array(arr, dtype=object)
         self.assertTrue(np.array_equiv(self.windows[1322.5:1326], val_wind))
 
         # Test slice indexing with boundary cases.
-        arr = [self.wind_two, self.wind_three, self.wind_four, self.wind_five]
+        arr = [self.W2, self.W3, self.W4, self.W5]
         val_wind = np.array(arr, dtype=object)
         self.assertTrue(np.array_equiv(self.windows[1322.3:1325], val_wind))
 
@@ -75,22 +99,104 @@ class TestWindows(TestCase):
 
         test_val = 0
         for window in self.windows:
-            start = window.start
+            start = window.rise_time if isinstance(window, VTW) else window.start_time
             self.assertLessEqual(test_val, start)
             test_val = start
 
-    def test_stats(self):
+    def test_get_window(self):
 
-        df = self.windows.stats()
-        self.assertIsNotNone(df)
+        self.assertEqual(self.windows.get_window(1320), self.W1)
+        self.assertEqual(self.windows.get_window(1322.5), self.W2)
+        self.assertEqual(self.windows.get_window(1324.5), self.W4)
+        self.assertEqual(self.windows.get_window(1325.5), self.W5)
+
+    def test_get_windows_in_range(self):
+
+        arr = [self.W2, self.W3, self.W4, self.W5]
+        val_wind = np.array(arr, dtype=object)
+        self.assertTrue(np.array_equiv(self.windows.get_windows_in_range(1320, 1326), val_wind))
 
     def test_to_numpy(self):
 
         np_arr = self.windows.to_numpy()
         self.assertIsInstance(np_arr, np.ndarray)
 
-    def test_save_encounters(self):
-        pass
+
+class TestVTWHandler(TestCase):
+
+    def setUp(self) -> None:
+
+        self.windows = VTWHandler()
+
+        self.W1 = VTW(1319, 1319.2)
+        self.W2 = VTW(1322.3, 1322.31)
+        self.W3 = VTW(1324, 1324.2)
+        self.W4 = VTW(1324.3, 1325.3)
+        self.W5 = VTW(1325, 1326.1)
+
+        self.windows._add_window(self.W1)
+        self.windows._add_window(self.W2)
+        self.windows._add_window(self.W3)
+        self.windows._add_window(self.W4)
+        self.windows._add_window(self.W5)
+
+    def test_stats(self):
+
+        stats = self.windows.stats()
+        print(stats)
+        self.assertIsNotNone(stats)
+
+    def test_save(self):
+
+        self.windows.save('test_vtw.csv', ',')
+        self.assertTrue(os.path.isfile('test_vtw.csv'))
+
+        data = np.loadtxt('test_vtw.csv', delimiter=',', skiprows=1)
+        for i, window in enumerate(self.windows):
+
+            self.assertEqual(window.rise_time, data[i, 0])
+            self.assertEqual(window.set_time, data[i, 1])
+            self.assertEqual(window.duration, data[i, 2])
+
+        os.remove('test_vtw.csv')
+
+
+class TestOWHandler(TestCase):
+
+    def setUp(self) -> None:
+
+        self.windows = OWHandler()
+
+        location = GroundPosition(43.6532, 79.3832, 0.076)
+
+        self.W1 = OW(1319, 30, location, 8, 1319.2)
+        self.W2 = OW(1322.3, 20, location, 9, 1322.31)
+        self.W3 = OW(1324, 32, location, 4, 1324.2)
+        self.W4 = OW(1324.3, 28, location, 7, 1325.3)
+        self.W5 = OW(1325, 10, location, 10, 1326.1)
+
+        self.windows._add_window(self.W1)
+        self.windows._add_window(self.W2)
+        self.windows._add_window(self.W3)
+        self.windows._add_window(self.W4)
+        self.windows._add_window(self.W5)
+
+    def test_save(self):
+
+        self.windows.save('test_ow.csv', ',')
+        self.assertTrue(os.path.isfile('test_ow.csv'))
+
+        data = np.loadtxt('test_ow.csv', delimiter=',', skiprows=1)
+        for i, window in enumerate(self.windows):
+
+            self.assertEqual(window.location.lat, data[i, 0])
+            self.assertEqual(window.location.lon, data[i, 1])
+            self.assertEqual(window.start_time, data[i, 2])
+            self.assertEqual(window.duration, data[i, 3])
+            self.assertEqual(window.quality, data[i, 4])
+            self.assertEqual(window.deadline, data[i, 5])
+
+        os.remove('test_ow.csv')
 
 
 if __name__ == "__main__":

--- a/tests/test_encounter/test_windows.py
+++ b/tests/test_encounter/test_windows.py
@@ -72,7 +72,7 @@ class TestWindows(TestCase):
             window_times = np.linspace(rise_time, set_time, 10)
 
             self.assertTrue(np.all(elevation(window_times) > vis_threshold))
-        
+
         # Test the window generator for day only case.
 
         vis_threshold, lighting, tol = 10, 1, 1e-5
@@ -85,7 +85,7 @@ class TestWindows(TestCase):
 
             self.assertTrue(np.all(elevation(window_times) > vis_threshold))
             self.assertTrue(np.all((0 < sa)))
-        
+
         # Test the window generator for night only case.
 
         vis_threshold, lighting, tol = 10, -1, 1e-5


### PR DESCRIPTION
The `VTW-OW-framework` branch contains changes that lay the framework for the future inclusion of a scheduling algorithm. The primary differences involve the window handling data structures and window generation workflow.

The `Window` class was replaced with the `VTW` and `OW` classes. The first defines visible time encounters that will be returned from the window generation workflow. The latter establishes the observation windows, which will be the request satisfying VTW with a determined start time and duration. The `Windows` class was also reduced to the `WindowHandling` class, inherited into the `VTWHandling`  and `OWHandling` classes. The need for the different window handling data structures arises from the different use cases of the `VTW` and `OW` classes.

The window generation workflow was simplified to purely elevation and lighting constrained windows. The returned windows are visible time windows. Implementing a scheduler will select the precise window times to get the observation windows.

Note that Sphinx documentation has been updated to reflect all changes except those with the `OW` and `OWHandling` classes which are not yet worthwhile to the public eye until the scheduler is implemented.
