### PR TITLE
Cel 30 improving quantity usability

### DIFF
--- a/celest/angle_strings.py
+++ b/celest/angle_strings.py
@@ -36,7 +36,7 @@ def _ISO6709_representation(latitude: Quantity, longitude: Quantity, height:
 
 
 def _get_latitude_string(latitude: Quantity) -> str:
-    sexigesimal_latitude = _get_sexagesimal_string(abs(latitude.to(u.deg).data))
+    sexigesimal_latitude = _get_sexagesimal_string(abs(latitude.to(u.deg)))
     direction = "N" if latitude.data >= 0 else "S"
 
     return sexigesimal_latitude + direction
@@ -52,7 +52,7 @@ def _get_sexagesimal_string(absolute_deg_angle: float) -> str:
 
 
 def _get_longitude_string(longitude: Quantity) -> str:
-    sexigesimal_longitude = _get_sexagesimal_string(abs(longitude.to(u.deg).data))
+    sexigesimal_longitude = _get_sexagesimal_string(abs(longitude.to(u.deg)))
     direction = "E" if longitude.data >= 0 else "W"
 
     return sexigesimal_longitude + direction

--- a/celest/coordinates/astronomical_quantities.py
+++ b/celest/coordinates/astronomical_quantities.py
@@ -45,7 +45,7 @@ def earth_rotation_angle(julian: Quantity) -> Quantity:
     >>> julian = Quantity(30462.50000, u.jd2000)
     >>> era = earth_rotation_angle(julian)
     """
-    days_since_jd2000 = julian.data - JD2000_DATE
+    days_since_jd2000 = julian.to(u.jd2000) - JD2000_DATE
     earth_rotation_angles = (EARTH_ROTATION_RATE_DEG_PER_DAY *
                              days_since_jd2000 + ERA_AT_JD2000_DEG) % 360
     return Quantity(earth_rotation_angles, u.deg)
@@ -253,8 +253,8 @@ def conventional_precession_angles(julian: Quantity) -> Tuple:
 
 def _get_zeta_precession_angle(julian: Quantity) -> Quantity:
     t1, t2, t3, t4, t5 = _calculate_raw_elapsed_jd_century_powers(julian, 5)
-    result = 2.59796176 + 2306.0809506 * t1 + 0.3019015 * t2 + 0.0179663 * t3 - \
-        0.0000327 * t4 - 0.0000002 * t5
+    result = 2.59796176 + 2306.0809506 * t1 + 0.3019015 * t2 + \
+        0.0179663 * t3 - 0.0000327 * t4 - 0.0000002 * t5
     return Quantity(result, u.arcsec)
 
 
@@ -267,8 +267,8 @@ def _get_theta_precession_angle(julian: Quantity) -> Quantity:
 
 def _get_z_precession_angle(julian: Quantity) -> Quantity:
     t1, t2, t3, t4, t5 = _calculate_raw_elapsed_jd_century_powers(julian, 5)
-    result = - 2.5976176 + 2306.0803226 * t1 + 1.0947790 * t2 + 0.0182273 * t3 + \
-        0.0000470 * t4 - 0.0000003 * t5
+    result = - 2.5976176 + 2306.0803226 * t1 + 1.0947790 * t2 + \
+        0.0182273 * t3 + 0.0000470 * t4 - 0.0000003 * t5
     return Quantity(result, u.arcsec)
 
 
@@ -352,10 +352,10 @@ def apparent_obliquity(julian: Quantity) -> Quantity:
     >>> julian = Quantity(2446895.5, u.jd2000)
     >>> epsilon = apparent_obliquity(julian=julian)
     """
-    average_obliquity = mean_obliquity(julian).to(u.deg)
+    average_obliquity = mean_obliquity(julian)
     _, nutation_in_obliquity = nutation_components(julian)
 
-    return Quantity(average_obliquity + nutation_in_obliquity.to(u.deg), u.deg)
+    return average_obliquity + nutation_in_obliquity
 
 
 def from_julian(julian: Quantity) -> Tuple:
@@ -389,10 +389,10 @@ def from_julian(julian: Quantity) -> Tuple:
     (1957, 10, 4.81)
     """
 
-    if isinstance(julian.data, (float, int)):
-        jd = np.array([julian.data]) + 0.5
+    if isinstance(julian.to(u.jd2000), (float, int)):
+        jd = np.array([julian.to(u.jd2000)]) + 0.5
     else:
-        jd = np.array(julian.data) + 0.5
+        jd = np.array(julian.to(u.jd2000)) + 0.5
     a, f = jd.astype(int), jd % 1
 
     ind = np.where(a >= 2291161)[0]

--- a/celest/coordinates/coordinate.py
+++ b/celest/coordinates/coordinate.py
@@ -41,12 +41,12 @@ class Coordinate:
     frame:
 
     >>> c = Coordinate(gcrs)
-    >>> itrs = c._convert_to(ITRS)
+    >>> itrs = c.convert_to(ITRS)
 
     By specifying a ground location, we can convert to the `AzEl` frame:
 
     >>> location = GroundLocation(43.6532, -79.3832, 76, u.deg, u.m)
-    >>> azel = c._convert_to(AzEl, location)
+    >>> azel = c.convert_to(AzEl, location)
     """
 
     def __init__(self, position: Literal[ITRS, GCRS, WGS84]):

--- a/celest/coordinates/coordinate.py
+++ b/celest/coordinates/coordinate.py
@@ -41,12 +41,12 @@ class Coordinate:
     frame:
 
     >>> c = Coordinate(gcrs)
-    >>> itrs = c.convert_to(ITRS)
+    >>> itrs = c._convert_to(ITRS)
 
     By specifying a ground location, we can convert to the `AzEl` frame:
 
     >>> location = GroundLocation(43.6532, -79.3832, 76, u.deg, u.m)
-    >>> azel = c.convert_to(AzEl, location)
+    >>> azel = c._convert_to(AzEl, location)
     """
 
     def __init__(self, position: Literal[ITRS, GCRS, WGS84]):

--- a/celest/coordinates/frames/gcrs.py
+++ b/celest/coordinates/frames/gcrs.py
@@ -49,10 +49,6 @@ class GCRS(Position3d):
 
     >>> gcrs = GCRS(julian, x, y, z, u.km)
 
-    Convert to the `ITRS` frame:
-
-    >>> itrs = gcrs._convert_to(ITRS)
-
     Save `GCRS` data to a text file:
 
     >>> gcrs.save_text_file("gcrs_data")

--- a/celest/coordinates/frames/gcrs.py
+++ b/celest/coordinates/frames/gcrs.py
@@ -51,7 +51,7 @@ class GCRS(Position3d):
 
     Convert to the `ITRS` frame:
 
-    >>> itrs = gcrs.convert_to(ITRS)
+    >>> itrs = gcrs._convert_to(ITRS)
 
     Save `GCRS` data to a text file:
 

--- a/celest/coordinates/frames/itrs.py
+++ b/celest/coordinates/frames/itrs.py
@@ -49,10 +49,6 @@ class ITRS(Position3d):
 
     >>> itrs = ITRS(julian, x, y, z, u.km)
 
-    Convert to the `GCRS` frame:
-
-    >>> gcrs = itrs._convert_to(GCRS)
-
     Save `ITRS` data to a text file:
 
     >>> itrs.save_text_file("gcrs_data")

--- a/celest/coordinates/frames/itrs.py
+++ b/celest/coordinates/frames/itrs.py
@@ -51,7 +51,7 @@ class ITRS(Position3d):
 
     Convert to the `GCRS` frame:
 
-    >>> gcrs = itrs.convert_to(GCRS)
+    >>> gcrs = itrs._convert_to(GCRS)
 
     Save `ITRS` data to a text file:
 

--- a/celest/coordinates/ground_location.py
+++ b/celest/coordinates/ground_location.py
@@ -1,10 +1,10 @@
 
 
+from celest.angle_strings import _ISO6709_representation
+from celest.constants import WGS84_MINOR_AXIS_KM, WGS84_MAJOR_AXIS_KM
 from celest.units.quantity import Quantity
 from celest.units.core import Unit
 from celest import units as u
-from celest.constants import WGS84_MINOR_AXIS_KM, WGS84_MAJOR_AXIS_KM
-from celest.angle_strings import _ISO6709_representation
 from math import cos, sin, sqrt
 
 
@@ -133,8 +133,7 @@ class GroundLocation:
         """
 
         m = self._meridional_radius_of_curvature()
-        itrs_x = (m + self._height.to(u.km)) * \
-            cos(self._latitude.to(u.rad)) * \
+        itrs_x = (m + self._height.to(u.km)) * cos(self._latitude.to(u.rad)) * \
             cos(self._longitude.to(u.rad))
 
         return Quantity(itrs_x, u.km)

--- a/celest/coordinates/ground_location.py
+++ b/celest/coordinates/ground_location.py
@@ -115,14 +115,14 @@ class GroundLocation:
            https://planetcalc.com/7721/.
         """
 
-        cos_latitude = cos(self._latitude.to(u.rad).data)
-        sin_latitude = sin(self._latitude.to(u.rad).data)
+        cos_latitude = cos(self._latitude.to(u.rad))
+        sin_latitude = sin(self._latitude.to(u.rad))
 
         numerator = (WGS84_MAJOR_AXIS_KM ** 2 * cos_latitude) ** 2 + \
                     (WGS84_MINOR_AXIS_KM ** 2 * sin_latitude) ** 2
         denominator = (WGS84_MAJOR_AXIS_KM * cos_latitude) ** 2 + \
                       (WGS84_MINOR_AXIS_KM * sin_latitude) ** 2
-        radius_km = sqrt(numerator / denominator) + self._height.to(u.km).data
+        radius_km = sqrt(numerator / denominator) + self._height.to(u.km)
 
         return Quantity(radius_km, u.km)
 
@@ -133,9 +133,9 @@ class GroundLocation:
         """
 
         m = self._meridional_radius_of_curvature()
-        itrs_x = (m + self._height.to(u.km).data) * \
-            cos(self._latitude.to(u.rad).data) * \
-            cos(self._longitude.to(u.rad).data)
+        itrs_x = (m + self._height.to(u.km)) * \
+            cos(self._latitude.to(u.rad)) * \
+            cos(self._longitude.to(u.rad))
 
         return Quantity(itrs_x, u.km)
 
@@ -144,7 +144,7 @@ class GroundLocation:
 
     def _meridional_radius_of_curvature(self):
         return WGS84_MAJOR_AXIS_KM / sqrt(1 - self._ellipse_eccentricity() **
-                                          2 * sin(self._latitude.to(u.rad).data) ** 2)
+                                          2 * sin(self._latitude.to(u.rad)) ** 2)
 
     @property
     def itrs_y(self) -> Quantity:
@@ -153,9 +153,9 @@ class GroundLocation:
         """
 
         m = self._meridional_radius_of_curvature()
-        itrs_y = (m + self._height.to(u.km).data) * \
-            cos(self._latitude.to(u.rad).data) * \
-            sin(self._longitude.to(u.rad).data)
+        itrs_y = (m + self._height.to(u.km)) * \
+            cos(self._latitude.to(u.rad)) * \
+            sin(self._longitude.to(u.rad))
 
         return Quantity(itrs_y, u.km)
 
@@ -167,7 +167,7 @@ class GroundLocation:
 
         e = self._ellipse_eccentricity()
         m = self._meridional_radius_of_curvature()
-        itrs_z = (m * (1 - e ** 2) + self._height.to(u.km).data) * \
-            sin(self._latitude.to(u.rad).data)
+        itrs_z = (m * (1 - e ** 2) + self._height.to(u.km)) * \
+            sin(self._latitude.to(u.rad))
 
         return Quantity(itrs_z, u.km)

--- a/celest/coordinates/ground_location.py
+++ b/celest/coordinates/ground_location.py
@@ -153,8 +153,7 @@ class GroundLocation:
         """
 
         m = self._meridional_radius_of_curvature()
-        itrs_y = (m + self._height.to(u.km)) * \
-            cos(self._latitude.to(u.rad)) * \
+        itrs_y = (m + self._height.to(u.km)) * cos(self._latitude.to(u.rad)) * \
             sin(self._longitude.to(u.rad))
 
         return Quantity(itrs_y, u.km)

--- a/celest/coordinates/nutation_precession_matrices.py
+++ b/celest/coordinates/nutation_precession_matrices.py
@@ -7,6 +7,7 @@ from celest.coordinates.astronomical_quantities import (
     conventional_precession_angles
 )
 from celest.units.quantity import Quantity
+from celest import units as u
 import numpy as np
 
 
@@ -81,9 +82,9 @@ def precession_matrix(julian: Quantity) -> np.ndarray:
 
     zeta, theta, z = conventional_precession_angles(julian)
 
-    a1 = np.radians(zeta.data / 3600)
-    a2 = np.radians(theta.data / 3600)
-    a3 = - np.radians(z.data / 3600)
+    a1 = zeta.to(u.rad)
+    a2 = theta.to(u.rad)
+    a3 = - z.to(u.rad)
 
     s1, c1 = np.sin(a1), np.cos(a1)
     s2, c2 = np.sin(a2), np.cos(a2)
@@ -130,11 +131,11 @@ def nutation_matrix(julian: Quantity) -> np.ndarray:
 
     nutation_in_longitude, nutation_in_obliquity = nutation_components(julian)
     t1, t2, t3 = _calculate_raw_elapsed_jd_century_powers(julian, 3)
-    eps_A = 3600 * mean_obliquity(julian).data - 46.84024 * t1 - 0.00059 * t2 + 0.001813 * t3
+    eps_A = mean_obliquity(julian).to(u.arcsec) - 46.84024 * t1 - 0.00059 * t2 + 0.001813 * t3
 
     a1 = np.radians(eps_A / 3600)
-    a2 = - np.radians(nutation_in_longitude.data / 3600)
-    a3 = - np.radians(eps_A / 3600 + nutation_in_obliquity.data / 3600)
+    a2 = - nutation_in_longitude.to(u.rad)
+    a3 = - np.radians(eps_A / 3600 + nutation_in_obliquity.to(u.deg))
 
     s1, c1 = np.sin(a1), np.cos(a1)
     s2, c2 = np.sin(a2), np.cos(a2)

--- a/celest/coordinates/transforms.py
+++ b/celest/coordinates/transforms.py
@@ -175,11 +175,11 @@ def _itrs_to_wgs84(itrs: ITRS) -> WGS84:
         raise ValueError(f"Input data is in the {itrs.__class__} frame and not"
                          " the ITRS frame.")
 
-    julian = itrs.time.data
+    julian = itrs.time.to(u.jd2000)
 
-    itrs_x = itrs.x.to(u.km).data
-    itrs_y = itrs.y.to(u.km).data
-    itrs_z = itrs.z.to(u.km).data
+    itrs_x = itrs.x.to(u.km)
+    itrs_y = itrs.y.to(u.km)
+    itrs_z = itrs.z.to(u.km)
 
     latitude = np.arctan(itrs_z / np.sqrt(itrs_x ** 2 + itrs_y ** 2))
     longitude = np.arctan2(itrs_y, itrs_x)
@@ -224,9 +224,9 @@ def _altitude(itrs: ITRS) -> np.ndarray:
 
     tol = 10e-10
 
-    itrs_x = itrs.x.to(u.km).data
-    itrs_y = itrs.y.to(u.km).data
-    itrs_z = itrs.z.to(u.km).data
+    itrs_x = itrs.x.to(u.km)
+    itrs_y = itrs.y.to(u.km)
+    itrs_z = itrs.z.to(u.km)
 
     e = np.sqrt(1 - b ** 2 / a ** 2)
     p = np.sqrt(itrs_x ** 2 + itrs_y ** 2)
@@ -285,11 +285,11 @@ def _wgs84_to_itrs(wgs84: WGS84) -> ITRS:
         raise ValueError(f"Input data is in the {wgs84.__class__} frame and not"
                          " the WGS84 frame.")
 
-    julian = wgs84.time.data
+    julian = wgs84.time.to(u.jd2000)
 
-    latitude = wgs84.latitude.to(u.rad).data
-    longitude = wgs84.longitude.to(u.rad).data
-    height = wgs84.height.to(u.km).data
+    latitude = wgs84.latitude.to(u.rad)
+    longitude = wgs84.longitude.to(u.rad)
+    height = wgs84.height.to(u.km)
 
     e = np.sqrt(1 - WGS84_MINOR_AXIS_KM ** 2 / WGS84_MAJOR_AXIS_KM ** 2)
     n = WGS84_MAJOR_AXIS_KM / np.sqrt(1 - e ** 2 * np.sin(latitude) ** 2)
@@ -347,14 +347,13 @@ def _azimuth(itrs: ITRS, location: GroundLocation) -> np.ndarray:
         1-D array containing azimuth angles in degrees.
     """
 
-    sat_itrs = np.array([itrs.x.to(u.km).data, itrs.y.to(u.km).data,
-                         itrs.z.to(u.km).data]).T
-    ground_itrs = np.array([location.itrs_x.to(u.km).data,
-                            location.itrs_y.to(u.km).data,
-                            location.itrs_z.to(u.km).data])
+    sat_itrs = np.array([itrs.x.to(u.km), itrs.y.to(u.km), itrs.z.to(u.km)]).T
+    ground_itrs = np.array([location.itrs_x.to(u.km),
+                            location.itrs_y.to(u.km),
+                            location.itrs_z.to(u.km)])
 
-    latitude = location.latitude.to(u.rad).data
-    radius = location.radius.to(u.km).data
+    latitude = location.latitude.to(u.rad)
+    radius = location.radius.to(u.km)
 
     ground_to_satellite = sat_itrs - ground_itrs
 
@@ -417,11 +416,10 @@ def _elevation(itrs: ITRS, location: GroundLocation) -> np.ndarray:
         1-D array containing elevation angles in degrees.
     """
 
-    sat_itrs = np.array([itrs.x.to(u.km).data, itrs.y.to(u.km).data,
-                         itrs.z.to(u.km).data]).T
-    ground_itrs = np.array([location.itrs_x.to(u.km).data,
-                            location.itrs_y.to(u.km).data,
-                            location.itrs_z.to(u.km).data])
+    sat_itrs = np.array([itrs.x.to(u.km), itrs.y.to(u.km), itrs.z.to(u.km)]).T
+    ground_itrs = np.array([location.itrs_x.to(u.km),
+                            location.itrs_y.to(u.km),
+                            location.itrs_z.to(u.km)])
 
     return 90 - _get_ang(sat_itrs - ground_itrs, ground_itrs)
 
@@ -461,7 +459,7 @@ def _gcrs_to_lvlh(gcrs_position: GCRS, gcrs_velocity: GCRS) -> Tuple[LVLH, LVLH]
     velocity_dimension = gcrs_velocity.x.unit
 
     gcrs_position = deepcopy(gcrs_position)
-    julian = gcrs_position.time.data
+    julian = gcrs_position.time.to(u.jd2000)
 
     gcrs_x = gcrs_position.x.data.reshape((-1, 1))
     gcrs_y = gcrs_position.y.data.reshape((-1, 1))

--- a/celest/encounter/window_generator.py
+++ b/celest/encounter/window_generator.py
@@ -71,8 +71,8 @@ def generate_vtws(satellite: Satellite, location: GroundLocation,
         raise ValueError("vis_threshold must be between 0 and 90 degrees.")
 
     satellite_azel = Coordinate(satellite.position).convert_to(AzEl, location)
-    satellite_elevation = satellite_azel.elevation.to(u.deg).data
-    julian = satellite.position.time.to(u.jd2000).data
+    satellite_elevation = satellite_azel.elevation.to(u.deg)
+    julian = satellite.position.time.to(u.jd2000)
 
     window_indices = np.where(satellite_elevation > vis_threshold)[0]
 
@@ -109,7 +109,7 @@ def _lighting_constraint_indices(julian: np.ndarray, location: GroundLocation,
 def _get_night_constraint_indices(julian: np.ndarray, location:
                                   GroundLocation) -> np.ndarray:
     sun_elevation = _get_sun_elevation(julian, location)
-    return np.where(sun_elevation.to(u.deg).data < 0)[0]
+    return np.where(sun_elevation.to(u.deg) < 0)[0]
 
 
 def _get_sun_elevation(julian: np.ndarray, location: GroundLocation) -> Quantity:
@@ -134,4 +134,4 @@ def _get_sun_gcrs(julian: np.ndarray) -> GCRS:
 def _get_day_constraint_indices(julian: np.ndarray, location:
                                 GroundLocation) -> np.ndarray:
     sun_elevation = _get_sun_elevation(julian, location)
-    return np.where(sun_elevation.to(u.deg).data > 0)[0]
+    return np.where(sun_elevation.to(u.deg) > 0)[0]

--- a/celest/encounter/window_generator.py
+++ b/celest/encounter/window_generator.py
@@ -71,10 +71,9 @@ def generate_vtws(satellite: Satellite, location: GroundLocation,
         raise ValueError("vis_threshold must be between 0 and 90 degrees.")
 
     satellite_azel = Coordinate(satellite.position).convert_to(AzEl, location)
-    satellite_elevation = satellite_azel.elevation.to(u.deg)
     julian = satellite.position.time.to(u.jd2000)
 
-    window_indices = np.where(satellite_elevation > vis_threshold)[0]
+    window_indices = np.where(satellite_azel.elevation.to(u.deg) > vis_threshold)[0]
 
     lighting_indices = _lighting_constraint_indices(julian, location, lighting)
     window_indices = np.intersect1d(window_indices, lighting_indices)

--- a/celest/encounter/window_handling.py
+++ b/celest/encounter/window_handling.py
@@ -242,12 +242,12 @@ class WindowCollection:
         yaw = []
 
         for window in self._window_data:
-            start_time.append(window.start_time.to(u.jd2000).data)
-            duration.append(window.duration.to(u.s).data)
+            start_time.append(window.start_time.to(u.jd2000))
+            duration.append(window.duration.to(u.s))
             location.append(window.location)
-            roll.append(window.attitude.roll.to(u.deg).data[0])
-            pitch.append(window.attitude.pitch.to(u.deg).data[0])
-            yaw.append(window.attitude.yaw.to(u.deg).data[0])
+            roll.append(window.attitude.roll.to(u.deg)[0])
+            pitch.append(window.attitude.pitch.to(u.deg)[0])
+            yaw.append(window.attitude.yaw.to(u.deg)[0])
 
         return [
             ["Start Time", Quantity(np.array(start_time), u.jd2000)],

--- a/celest/satellite.py
+++ b/celest/satellite.py
@@ -149,20 +149,20 @@ class Satellite:
         lvlh_position_array = lvlh_position.to_numpy(u.km)
 
         ground_itrs = ITRS(
-            self.position.time.data,
+            self.position.time.to(u.jd2000),
             np.full((len(lvlh_position.x.data),),
-                    location.itrs_x.to(u.km).data),
+                    location.itrs_x.to(u.km)),
             np.full((len(lvlh_position.y.data),),
-                    location.itrs_y.to(u.km).data),
+                    location.itrs_y.to(u.km)),
             np.full((len(lvlh_position.z.data),),
-                    location.itrs_z.to(u.km).data),
+                    location.itrs_z.to(u.km)),
             u.km
         )
         ground_gcrs = _itrs_to_gcrs(ground_itrs)
         ground_gcrs = np.array([
-            ground_gcrs.x.to(u.km).data,
-            ground_gcrs.y.to(u.km).data,
-            ground_gcrs.z.to(u.km).data
+            ground_gcrs.x.to(u.km),
+            ground_gcrs.y.to(u.km),
+            ground_gcrs.z.to(u.km)
         ]).T
 
         transformation_matrix = _gcrs_to_lvlh_matrix(
@@ -190,7 +190,7 @@ class Satellite:
         pitch = np.arctan2(a31, a33)
         yaw = np.arctan2(a12, a22)
 
-        return Attitude(self.position.time.data, roll, pitch, yaw, u.rad,
+        return Attitude(self.position.time.to(u.jd2000), roll, pitch, yaw, u.rad,
                         location)
 
     def distance(self, location: GroundLocation) -> Quantity:
@@ -208,9 +208,9 @@ class Satellite:
         """
 
         distance = np.linalg.norm(np.array([
-            self.position.x.to(u.km).data - location.itrs_x.to(u.km).data,
-            self.position.y.to(u.km).data - location.itrs_y.to(u.km).data,
-            self.position.z.to(u.km).data - location.itrs_z.to(u.km).data
+            self.position.x.to(u.km) - location.itrs_x.to(u.km),
+            self.position.y.to(u.km) - location.itrs_y.to(u.km),
+            self.position.z.to(u.km) - location.itrs_z.to(u.km)
         ]), axis=0)
 
         return Quantity(distance, u.km)
@@ -234,14 +234,14 @@ class Satellite:
         """
 
         satellite_itrs = np.array([
-            self.position.x.to(u.km).data,
-            self.position.y.to(u.km).data,
-            self.position.z.to(u.km).data
+            self.position.x.to(u.km),
+            self.position.y.to(u.km),
+            self.position.z.to(u.km)
         ]).T
         ground_to_satellite_itrs = np.array([
-            self.position.x.to(u.km).data - location.itrs_x.to(u.km).data,
-            self.position.y.to(u.km).data - location.itrs_y.to(u.km).data,
-            self.position.z.to(u.km).data - location.itrs_z.to(u.km).data
+            self.position.x.to(u.km) - location.itrs_x.to(u.km),
+            self.position.y.to(u.km) - location.itrs_y.to(u.km),
+            self.position.z.to(u.km) - location.itrs_z.to(u.km)
         ]).T
         angles = _get_ang(ground_to_satellite_itrs, satellite_itrs)
 

--- a/celest/schedule/insertion_operators.py
+++ b/celest/schedule/insertion_operators.py
@@ -26,7 +26,7 @@ def insert_first_n_requests(request_handler, number_to_insert):
         look_angle = request_handler.look_angle(request_index)
         request_vtw_list = request_handler.vtw_list(request_index)
 
-        duration_in_days = Quantity(duration.to(u.s).data / 86400, u.jd2000)
+        duration_in_days = Quantity(duration.to(u.s) / 86400, u.jd2000)
 
         for vtw_index, vtw in enumerate(request_vtw_list):
 
@@ -58,11 +58,11 @@ def insert_first_n_requests(request_handler, number_to_insert):
 
 
 def _look_angle_time(look_angle, desired_look_angle, julian, start, end):
-    julian = julian.to(u.jd2000).data
-    look_angle = look_angle.to(u.deg).data - desired_look_angle.to(u.deg).data
+    julian = julian.to(u.jd2000)
+    look_angle = look_angle.to(u.deg) - desired_look_angle.to(u.deg)
 
-    left_value_index = np.where(julian == start.to(u.jd2000).data)[0][0]
-    right_value_index = np.where(julian == end.to(u.jd2000).data)[0][0]
+    left_value_index = np.where(julian == start.to(u.jd2000))[0][0]
+    right_value_index = np.where(julian == end.to(u.jd2000))[0][0]
 
     left_look_angle = look_angle[left_value_index]
     right_look_angle = look_angle[right_value_index]
@@ -87,10 +87,10 @@ def image_quality_is_met(vtw, start, minimum_image_quality):
 
 
 def image_quality(vtw, start):
-    nadir_time = ((vtw.rise_time + vtw.set_time) / 2).to(u.jd2000).data
-    start_time = start.to(u.jd2000).data
-    ride_time = vtw.rise_time.to(u.jd2000).data
-    return math.floor(10 - 9 * abs(start_time - nadir_time) / (nadir_time - ride_time))
+    nadir_time = ((vtw.rise_time + vtw.set_time) / 2).to(u.jd2000)
+    start_time = start.to(u.jd2000)
+    rise_time = vtw.rise_time.to(u.jd2000)
+    return math.floor(10 - 9 * abs(start_time - nadir_time) / (nadir_time - rise_time))
 
 
 def does_conflict_exists(request_handler, start, duration_in_days):
@@ -98,7 +98,7 @@ def does_conflict_exists(request_handler, start, duration_in_days):
         if not request[0]:
             continue
         scheduled_start = request[2]
-        scheduled_duration = Quantity(request[3].to(u.s).data / 86400, u.jd2000)
+        scheduled_duration = Quantity(request[3].to(u.s) / 86400, u.jd2000)
         scheduled_end = scheduled_start + scheduled_duration
 
         if start <= scheduled_start < start + duration_in_days:

--- a/celest/time.py
+++ b/celest/time.py
@@ -518,9 +518,9 @@ class Time:
 
         ut1 = self.ut1().to(u.hourangle)
         right_ascension_of_sun = sun_right_ascension(self.julian).to(u.hourangle)
-        eqn_of_equinoxes = equation_of_equinoxes(self.julian)
+        eqn_of_equinoxes = equation_of_equinoxes(self.julian).to(u.deg)
 
-        last = ut1 - 12 + right_ascension_of_sun + eqn_of_equinoxes.to(u.deg) +\
+        last = ut1 - 12 + right_ascension_of_sun + eqn_of_equinoxes +\
             np.array(longitude) / 15
 
         return Quantity(last % 24, u.hourangle)

--- a/celest/time.py
+++ b/celest/time.py
@@ -30,7 +30,7 @@ class Time:
     julian : array_like
         1-D array containing time data in Julian days.
 
-        If time data is not in the J2000 epoch, an offset must be pased in to
+        If time data is not in the J2000 epoch, an offset must be passed in to
         be added to the julian times.
     offset : float, optional
         Offset to convert input time data to the J2000 epoch, default to zero.
@@ -89,10 +89,11 @@ class Time:
         julian : array_like
             1-D array containing time data in Julian days.
 
-            If time data is not in the J2000 epoch, an offset must be pased in to
-            be added to the julian times.
+            If time data is not in the J2000 epoch, an offset must be passed in
+            to be added to the julian times.
         offset : float, optional
-            Offset to convert input time data to the J2000 epoch, default to zero.
+            Offset to convert input time data to the J2000 epoch, default to
+            zero.
         """
 
         time = np.array(julian)
@@ -364,7 +365,7 @@ class Time:
                   datetime.datetime(2013, 1, 1, 0, 59, 59, 999987)])
         """
 
-        year, month, day = from_julian(self._julian)
+        year, month, day = from_julian(Quantity(self._julian, u.jd2000))
         full_days, fractional_day = day.astype(int), day % 1
 
         datetime_list = []
@@ -517,9 +518,9 @@ class Time:
 
         ut1 = self.ut1().to(u.hourangle)
         right_ascension_of_sun = sun_right_ascension(self.julian).to(u.hourangle)
-        eqn_of_equinoxes = equation_of_equinoxes(self.julian).to(u.deg)
+        eqn_of_equinoxes = equation_of_equinoxes(self.julian)
 
-        last = ut1 - 12 + right_ascension_of_sun + eqn_of_equinoxes +\
-               np.array(longitude) / 15
+        last = ut1 - 12 + right_ascension_of_sun + eqn_of_equinoxes.to(u.deg) +\
+            np.array(longitude) / 15
 
         return Quantity(last % 24, u.hourangle)

--- a/celest/time.py
+++ b/celest/time.py
@@ -262,7 +262,7 @@ class Time:
         Quantity(np.array([10.97157662, 12.47807655]), Unit("hourangle"))
         """
 
-        tha = (self.true_solar_time(longitude).to(u.hourangle).data - 12) % 24
+        tha = (self.true_solar_time(longitude).to(u.hourangle) - 12) % 24
         return Quantity(tha, u.hourangle)
 
     def mean_hour_angle(self, longitude: np.ndarray) -> Quantity:
@@ -312,7 +312,7 @@ class Time:
         Quantity(np.array([22.83066666]), Unit("hourangle"))
         """
 
-        mha = (self.mean_solar_time(longitude).to(u.hourangle).data - 12) % 24
+        mha = (self.mean_solar_time(longitude).to(u.hourangle) - 12) % 24
         return Quantity(mha, u.hourangle)
 
     def ut1(self) -> Quantity:
@@ -444,8 +444,8 @@ class Time:
         Quantity(np.array([9.98419514, 16.62892539, 17.78123885]), Unit("hourangle"))
         """
 
-        hour_angle = self.mean_hour_angle(longitude).to(u.hourangle).data
-        right_ascension = sun_right_ascension(self.julian).to(u.hourangle).data
+        hour_angle = self.mean_hour_angle(longitude).to(u.hourangle)
+        right_ascension = sun_right_ascension(self.julian).to(u.hourangle)
 
         return Quantity((hour_angle + right_ascension) % 24, u.hourangle)
 
@@ -476,8 +476,8 @@ class Time:
                   7.723465])
         """
 
-        gmst = self.gmst().data
-        eqn_of_equinoxes = equation_of_equinoxes(self.julian).to(u.deg).data
+        gmst = self.gmst().to(u.hourangle)
+        eqn_of_equinoxes = equation_of_equinoxes(self.julian).to(u.deg)
 
         return Quantity(gmst + eqn_of_equinoxes, u.hourangle)
 
@@ -515,9 +515,9 @@ class Time:
                   17.78148932])
         """
 
-        ut1 = self.ut1().to(u.hourangle).data
-        right_ascension_of_sun = sun_right_ascension(self.julian).to(u.hourangle).data
-        eqn_of_equinoxes = equation_of_equinoxes(self.julian).to(u.deg).data
+        ut1 = self.ut1().to(u.hourangle)
+        right_ascension_of_sun = sun_right_ascension(self.julian).to(u.hourangle)
+        eqn_of_equinoxes = equation_of_equinoxes(self.julian).to(u.deg)
 
         last = ut1 - 12 + right_ascension_of_sun + eqn_of_equinoxes +\
                np.array(longitude) / 15

--- a/celest/units/core.py
+++ b/celest/units/core.py
@@ -1,7 +1,6 @@
 
 
 from celest.units.display import _to_string, get_dimension_string
-from typing import Union
 
 
 class BaseUnit:
@@ -102,11 +101,11 @@ class NamedUnit(BaseUnit):
         The short name of the unit is used as its namespace identifier.
     long_name : str
         The long name of the unit.
-    namespace : dict
+    namespace : dict, optional
         The namespace to insert the unit into.
     """
 
-    def __init__(self, short_name: str, long_name: str, namespace: dict) -> None:
+    def __init__(self, short_name: str, long_name: str, namespace: dict=None) -> None:
 
         super().__init__()
 
@@ -152,14 +151,16 @@ class Unit(NamedUnit, BaseUnit):
         The short name of the unit is used as its namespace identifier.
     long_name : str
         The long name of the unit.
-    namespace : dict
+    namespace : dict, optional
         The namespace to insert the unit into.
     base_units : BaseUnit, optional
         The base units of the unit. That is, how the new unit relates to a base
         SI unit.
+
+        For example, a kilometer unit has the base units of `1000 * u.m`.
     """
 
-    def __init__(self, short_name: str, long_name: str, namespace: dict,
+    def __init__(self, short_name: str, long_name: str, namespace: dict=None,
                  base_units: BaseUnit=None) -> None:
 
         super().__init__(short_name, long_name, namespace)
@@ -214,7 +215,7 @@ class CompoundUnit(BaseUnit):
         The list of powers of the unit.
     """
 
-    def __init__(self, scale: Union[int, float], bases: list, powers: list) -> None:
+    def __init__(self, scale: float, bases: list, powers: list) -> None:
 
         self._is_unity = False
 

--- a/celest/units/core.py
+++ b/celest/units/core.py
@@ -1,6 +1,7 @@
 
 
 from celest.units.display import _to_string, get_dimension_string
+from typing import Union
 
 
 class BaseUnit:
@@ -9,31 +10,34 @@ class BaseUnit:
     The `BaseUnit` class defines the operations required for handling units.
     """
 
-    def __str__(self):
+    def __str__(self) -> str:
         return _to_string(self)
 
     @property
-    def dimension(self):
+    def dimension(self) -> str:
+        """
+        Return the dimension string of the unit.
+        """
         return get_dimension_string(self)
 
     @property
-    def scale(self):
+    def scale(self) -> float:
         """
-        Return scale of the unit.
+        Return the scale of the unit.
         """
         return 1.0
 
     @property
-    def bases(self):
+    def bases(self) -> list:
         """
-        Return the bases of the unit.
+        Return the list of bases of the unit.
         """
         return [self]
 
     @property
-    def powers(self):
+    def powers(self) -> list:
         """
-        Return the powers of the unit.
+        Return the list of powers of the unit.
         """
         return [1]
 
@@ -77,7 +81,7 @@ class BaseUnit:
         elif isinstance(other, (float, int)):
             return CompoundUnit(other, [self], [1])
 
-    def is_unity(self):
+    def is_unity(self) -> bool:
         """
         Return `True` if the unit is unity.
         """
@@ -89,29 +93,46 @@ class NamedUnit(BaseUnit):
 
     The `NamedUnit` class is a `BaseUnit` with a name and associated with a
     namespace.
+
+    Parameters
+    ----------
+    short_name : str
+        The short name of the unit.
+
+        The short name of the unit is used as its namespace identifier.
+    long_name : str
+        The long name of the unit.
+    namespace : dict
+        The namespace to insert the unit into.
     """
 
-    def __init__(self, short_name, long_name, namespace=None):
+    def __init__(self, short_name: str, long_name: str, namespace: dict) -> None:
 
         super().__init__()
 
         self._short_name = short_name
         self._long_name = long_name
 
-        self.insert_into_namespace(namespace)
+        self._insert_into_namespace(namespace)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "NamedUnit(\"" + _to_string(self) + "\")"
 
     @property
-    def short_name(self):
+    def short_name(self) -> str:
+        """
+        Return the short name of the unit.
+        """
         return self._short_name
 
     @property
-    def long_name(self):
+    def long_name(self) -> str:
+        """
+        Return the long name of the unit.
+        """
         return self._long_name
 
-    def insert_into_namespace(self, namespace):
+    def _insert_into_namespace(self, namespace):
 
         if namespace is not None and self._short_name not in namespace:
             namespace[self._short_name] = self
@@ -122,9 +143,24 @@ class Unit(NamedUnit, BaseUnit):
 
     The `Unit` class is the main unit object that is associated with a
     namespace and has a name.
+
+    Parameters
+    ----------
+    short_name : str
+        The short name of the unit.
+
+        The short name of the unit is used as its namespace identifier.
+    long_name : str
+        The long name of the unit.
+    namespace : dict
+        The namespace to insert the unit into.
+    base_units : BaseUnit, optional
+        The base units of the unit. That is, how the new unit relates to a base
+        SI unit.
     """
 
-    def __init__(self, short_name, long_name, namespace=None, base_units=None):
+    def __init__(self, short_name: str, long_name: str, namespace: dict,
+                 base_units: BaseUnit=None) -> None:
 
         super().__init__(short_name, long_name, namespace)
 
@@ -141,23 +177,23 @@ class Unit(NamedUnit, BaseUnit):
         return "Unit(\"" + _to_string(self) + "\")"
 
     @property
-    def scale(self):
+    def scale(self) -> float:
         """
-        Return scale of the unit.
+        Return the scale of the unit.
         """
         return self._scale
 
     @property
-    def bases(self):
+    def bases(self) -> list:
         """
-        Return the bases of the unit.
+        Return the list of bases of the unit.
         """
         return self._bases
 
     @property
-    def powers(self):
+    def powers(self) -> list:
         """
-        Return the powers of the unit.
+        Return the list of powers of the unit.
         """
         return self._powers
 
@@ -167,9 +203,18 @@ class CompoundUnit(BaseUnit):
 
     The `CompoundUnit` class handles more complicated units that are
     combinations of multiple `Unit` objects.
+
+    Parameters
+    ----------
+    scale : float
+        The scale of the unit.
+    bases : list
+        The list of bases of the unit.
+    powers : list
+        The list of powers of the unit.
     """
 
-    def __init__(self, scale, bases, powers):
+    def __init__(self, scale: Union[int, float], bases: list, powers: list) -> None:
 
         self._is_unity = False
 
@@ -190,22 +235,22 @@ class CompoundUnit(BaseUnit):
             self._powers = powers
             self._expand_and_collect()
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "CompoundUnit(\"" + _to_string(self) + "\")"
 
     @property
-    def scale(self):
+    def scale(self) -> float:
         return self._scale
 
     @property
-    def bases(self):
+    def bases(self) -> list:
         return self._bases
 
     @property
-    def powers(self):
+    def powers(self) -> list:
         return self._powers
 
-    def _expand_and_collect(self):
+    def _expand_and_collect(self) -> None:
         """
         Remove all instances of composite units in `_bases` and `_powers`.
         """
@@ -244,5 +289,5 @@ class CompoundUnit(BaseUnit):
 
         self._is_unity = True if not len(self._bases) else False
 
-    def is_unity(self):
+    def is_unity(self) -> bool:
         return self._is_unity

--- a/celest/units/quantity.py
+++ b/celest/units/quantity.py
@@ -33,7 +33,7 @@ class Quantity:
     -------
     to(new_unit)
         Return a new Quantity object with the new unit.
-    convert_to(new_unit)
+    _convert_to(new_unit)
         Convert Quantity data to a different unit.
 
 
@@ -210,6 +210,28 @@ class Quantity:
         return self._unit
 
     def to(self, new_unit):
+        """Return the Quantity data in the new unit.
+
+        Parameters
+        ----------
+        new_unit : Unit, CompoundUnit
+            New unit with the same dimension as the current unit.
+
+        Returns
+        -------
+        Any
+            The Quantity data in the new unit.
+
+        Examples
+        --------
+        >>> quantity_in_meters = Quantity(5, u.m)
+        >>> quantity_in_meters.to(u.km)
+        0.005
+        """
+
+        return self._convert_to(new_unit).data
+
+    def _convert_to(self, new_unit):
         """Return a new Quantity object with the new unit.
 
         Parameters
@@ -224,39 +246,13 @@ class Quantity:
 
         Examples
         --------
-        >>> quantity_in_kilometers = quantity_in_meters.to(u.km)
-        """
-
-        quantity_in_new_unit = deepcopy(self)
-        quantity_in_new_unit.convert_to(new_unit)
-        return quantity_in_new_unit
-
-    def get_unit(self):
-        # TODO: Remove this method (not being used).
-        return self._unit
-
-    # TODO: Remove this method, it is not useful when we include the to method that returns data.
-    def convert_to(self, new_unit):
-        """Convert Quantity data to a different unit.
-
-        Parameters
-        ----------
-        new_unit : Unit, CompoundUnit
-            New unit with the same dimension as the current unit.
-
-        Examples
-        --------
         Initialize the `Quantity` object:
 
-        >>> q = Quantity(5, u.m)
-        >>> q.data
-        5
+        >>> quantity_in_meters = Quantity(5, u.m)
 
         Convert to kilometers:
 
-        >>> q.convert_to(u.km)
-        >>> q.data
-        0.005
+        >>> quantity_in_kilometers = quantity_in_meters._convert_to(u.km)
         """
 
         if self._unit.dimension != new_unit.dimension:
@@ -272,8 +268,11 @@ class Quantity:
             else:
                 return unit.scale
 
-        if repr(self._unit) == repr(new_unit):
-            return self
-        else:
-            self._data *= _get_unit_scale(self.unit) / _get_unit_scale(new_unit)
-            self._unit = new_unit
+        quantity_copy = deepcopy(self)
+
+        if repr(quantity_copy._unit) != repr(new_unit):
+            quantity_copy._data *= _get_unit_scale(
+                quantity_copy.unit) / _get_unit_scale(new_unit)
+            quantity_copy._unit = new_unit
+
+        return quantity_copy

--- a/celest/units/quantity.py
+++ b/celest/units/quantity.py
@@ -61,10 +61,10 @@ class Quantity:
             data = self._data + other
             return Quantity(data, self._unit)
         elif isinstance(other, Quantity):
-            if repr(self._unit) != repr(other._unit):
+            if self._unit.dimension != other._unit.dimension:
                 raise ArithmeticError(
-                    "Units must match for Quantity addition.")
-            data = self._data + other._data
+                    "Unit dimensions must match for Quantity addition.")
+            data = self._data + other.to(self._unit)
             return Quantity(data, self._unit)
         else:
             return NotImplemented
@@ -74,10 +74,10 @@ class Quantity:
             data = self._data + other
             return Quantity(data, self._unit)
         elif isinstance(other, Quantity):
-            if repr(self._unit) != repr(other._unit):
+            if self._unit.dimension != other._unit.dimension:
                 raise ArithmeticError(
-                    "Units must match for Quantity addition.")
-            data = self._data + other._data
+                    "Unit dimensions must match for Quantity addition.")
+            data = self._data + other.to(self._unit)
             return Quantity(data, self._unit)
         else:
             return NotImplemented
@@ -87,10 +87,10 @@ class Quantity:
             data = self._data - other
             return Quantity(data, self._unit)
         elif isinstance(other, Quantity):
-            if repr(self._unit) != repr(other._unit):
+            if self._unit.dimension != other._unit.dimension:
                 raise ArithmeticError(
-                    "Units must match for Quantity subtraction.")
-            data = self._data - other._data
+                    "Unit dimensions must match for Quantity subtraction.")
+            data = self._data - other.to(self._unit)
             return Quantity(data, self._unit)
         else:
             return NotImplemented
@@ -100,10 +100,10 @@ class Quantity:
             data = other - self._data
             return Quantity(data, self._unit)
         elif isinstance(other, Quantity):
-            if repr(self._unit) != repr(other._unit):
+            if self._unit.dimension != other._unit.dimension:
                 raise ArithmeticError(
-                    "Units must match for Quantity subtraction.")
-            data = other._data - self._data
+                    "Unit dimensions must match for Quantity subtraction.")
+            data = other.to(self._unit) - self._data
             return Quantity(data, self._unit)
         else:
             return NotImplemented
@@ -113,8 +113,12 @@ class Quantity:
             data = self.data * other
             return Quantity(data, self._unit)
         elif isinstance(other, Quantity):
-            data = self._data * other._data
-            unit = self._unit * other._unit
+            if self._unit.dimension == other._unit.dimension:
+                data = self._data * other.to(self._unit)
+                unit = self._unit ** 2
+            else:
+                data = self._data * other._data
+                unit = self._unit * other._unit
             return Quantity(data, unit)
         else:
             return NotImplemented
@@ -124,8 +128,12 @@ class Quantity:
             data = self._data * other
             return Quantity(data, self._unit)
         elif isinstance(other, Quantity):
-            data = self._data * other._data
-            unit = self._unit * other._unit
+            if self._unit.dimension == other._unit.dimension:
+                data = self._data * other.to(self._unit)
+                unit = self._unit ** 2
+            else:
+                data = self._data * other._data
+                unit = self._unit * other._unit
             return Quantity(data, unit)
         else:
             return NotImplemented
@@ -135,8 +143,12 @@ class Quantity:
             data = self._data / other
             return Quantity(data, self._unit)
         elif isinstance(other, Quantity):
-            data = self._data / other._data
-            unit = self._unit / other._unit
+            if self._unit.dimension == other._unit.dimension:
+                data = self._data / other.to(self._unit)
+                unit = self._unit / self._unit
+            else:
+                data = self._data / other._data
+                unit = self._unit / other._unit
             return Quantity(data, unit)
         else:
             return NotImplemented
@@ -147,57 +159,67 @@ class Quantity:
             unit = 1 / self._unit
             return Quantity(data, unit)
         elif isinstance(other, Quantity):
-            data = other._data / self._data
-            unit = other._unit / self._unit
+            if self._unit.dimension == other._unit.dimension:
+                data = other.to(self._unit) / self._data
+                unit = self._unit / self._unit
+            else:
+                data = other._data / self._data
+                unit = other._unit / self._unit
             return Quantity(data, unit)
         else:
             return NotImplemented
 
     def __eq__(self, other):
         if isinstance(other, Quantity):
-            if repr(self._unit) != repr(other._unit):
-                raise ArithmeticError("Units must match for comparison.")
-            return self._data == other._data
+            if self._unit.dimension != other._unit.dimension:
+                raise ArithmeticError(
+                    "Unit dimensions must match for comparison.")
+            return self._data == other.to(self._unit)
         else:
             return NotImplemented
 
     def __ne__(self, other):
         if isinstance(other, Quantity):
-            if repr(self._unit) != repr(other._unit):
-                raise ArithmeticError("Units must match for comparison.")
-            return self._data != other._data
+            if self._unit.dimension != other._unit.dimension:
+                raise ArithmeticError(
+                    "Unit dimensions must match for comparison.")
+            return self._data != other.to(self._unit)
         else:
             return NotImplemented
 
     def __lt__(self, other):
         if isinstance(other, Quantity):
-            if repr(self._unit) != repr(other._unit):
-                raise ArithmeticError("Units must match for comparison.")
-            return self._data < other._data
+            if self._unit.dimension != other._unit.dimension:
+                raise ArithmeticError(
+                    "Unit dimensions must match for comparison.")
+            return self._data < other.to(self._unit)
         else:
             return NotImplemented
 
     def __le__(self, other):
         if isinstance(other, Quantity):
-            if repr(self._unit) != repr(other._unit):
-                raise ArithmeticError("Units must match for comparison.")
-            return self._data <= other._data
+            if self._unit.dimension != other._unit.dimension:
+                raise ArithmeticError(
+                    "Unit dimensions must match for comparison.")
+            return self._data <= other.to(self._unit)
         else:
             return NotImplemented
 
     def __gt__(self, other):
         if isinstance(other, Quantity):
-            if repr(self._unit) != repr(other._unit):
-                raise ArithmeticError("Units must match for comparison.")
-            return self._data > other._data
+            if self._unit.dimension != other._unit.dimension:
+                raise ArithmeticError(
+                    "Unit dimensions must match for comparison.")
+            return self._data > other.to(self._unit)
         else:
             return NotImplemented
 
     def __ge__(self, other):
         if isinstance(other, Quantity):
-            if repr(self._unit) != repr(other._unit):
-                raise ArithmeticError("Units must match for comparison.")
-            return self._data >= other._data
+            if self._unit.dimension != other._unit.dimension:
+                raise ArithmeticError(
+                    "Unit dimensions must match for comparison.")
+            return self._data >= other.to(self._unit)
         else:
             return NotImplemented
 

--- a/celest/units/quantity.py
+++ b/celest/units/quantity.py
@@ -1,7 +1,8 @@
-from typing import Union, Any
+
 
 from celest.units.core import CompoundUnit, Unit
 from copy import deepcopy
+from typing import Any, Union
 
 
 class Quantity:
@@ -37,6 +38,37 @@ class Quantity:
     Examples
     --------
     >>> q = Quantity(5, u.m)
+
+    The data data, unit, and dimension string are available as attributes.
+
+    >>> q1.data
+    5
+    >>> q1.unit
+    Unit("m")
+    >>> q1.dimension
+    'L'
+
+    Quantities of the same dimension can be added or subtracted.
+
+    >>> q2 = Quantity(0.1, u.km)
+    >>> q3 = q1 + q2
+    >>> print(q3)
+    105.0 m
+
+    >>> q4 = q1 - q2
+    >>> print(q4)
+    -95.0 m
+
+    Quantities can be multiplied or divided.
+
+    >>> q5 = Quantity(2, u.s)
+    >>> q6 = q1 * q5
+    >>> print(q6)
+    10 m s
+
+    >>> q7 = q1 / q5
+    >>> print(q7)
+    2.5 m / s
     """
 
     def __init__(self, data: Any, unit: Union[Unit, CompoundUnit]) -> None:

--- a/celest/units/quantity.py
+++ b/celest/units/quantity.py
@@ -1,6 +1,6 @@
+from typing import Union, Any
 
-
-from celest.units.core import CompoundUnit
+from celest.units.core import CompoundUnit, Unit
 from copy import deepcopy
 
 
@@ -32,17 +32,29 @@ class Quantity:
     Methods
     -------
     to(new_unit)
-        Return a new Quantity object with the new unit.
-    _convert_to(new_unit)
-        Convert Quantity data to a different unit.
-
+        Return the Quantity data in the new unit.
 
     Examples
     --------
     >>> q = Quantity(5, u.m)
     """
 
-    def __init__(self, data, unit):
+    def __init__(self, data: Any, unit: Union[Unit, CompoundUnit]) -> None:
+        """Data with a unit.
+
+        The Quantity class holds both data and a unit together to allow for easy
+        unit conversions.
+
+        Parameters
+        ----------
+        data : Any
+            The data to be stored in the Quantity object.
+
+            To allow for unit conversions, the data object must have the
+            multiplication operations defined.
+        unit : Unit, CompoundUnit
+            The unit associated with the data.
+        """
 
         self._data = data
         self._unit = unit
@@ -164,18 +176,27 @@ class Quantity:
         return self.__eq__(other) or self.__gt__(other)
 
     @property
-    def data(self):
+    def data(self) -> Any:
+        """
+        Return the data of the quantity.
+        """
         return self._data
 
     @property
-    def unit(self):
+    def unit(self) -> Union[Unit, CompoundUnit]:
+        """
+        Return the unit of the quantity.
+        """
         return self._unit
 
     @property
-    def dimension(self):
+    def dimension(self) -> str:
+        """
+        Return the dimension string of the quantity.
+        """
         return self._unit.dimension
 
-    def to(self, new_unit):
+    def to(self, new_unit: Union[Unit, CompoundUnit]) -> Any:
         """Return the Quantity data in the new unit.
 
         Parameters
@@ -197,7 +218,7 @@ class Quantity:
 
         return self._convert_to(new_unit).data
 
-    def _convert_to(self, new_unit):
+    def _convert_to(self, new_unit: Union[Unit, CompoundUnit]) -> "Quantity":
         """Return a new Quantity object with the new unit.
 
         Parameters

--- a/celest/units/quantity.py
+++ b/celest/units/quantity.py
@@ -63,50 +63,20 @@ class Quantity:
         elif isinstance(other, Quantity):
             if self._unit.dimension != other._unit.dimension:
                 raise ArithmeticError(
-                    "Unit dimensions must match for Quantity addition.")
+                    "Unit dimensions must match for addition/subtraction.")
             data = self._data + other.to(self._unit)
             return Quantity(data, self._unit)
         else:
             return NotImplemented
 
     def __radd__(self, other):
-        if isinstance(other, (float, int)):
-            data = self._data + other
-            return Quantity(data, self._unit)
-        elif isinstance(other, Quantity):
-            if self._unit.dimension != other._unit.dimension:
-                raise ArithmeticError(
-                    "Unit dimensions must match for Quantity addition.")
-            data = self._data + other.to(self._unit)
-            return Quantity(data, self._unit)
-        else:
-            return NotImplemented
+        return self.__add__(other)
 
     def __sub__(self, other):
-        if isinstance(other, (float, int)):
-            data = self._data - other
-            return Quantity(data, self._unit)
-        elif isinstance(other, Quantity):
-            if self._unit.dimension != other._unit.dimension:
-                raise ArithmeticError(
-                    "Unit dimensions must match for Quantity subtraction.")
-            data = self._data - other.to(self._unit)
-            return Quantity(data, self._unit)
-        else:
-            return NotImplemented
+        return self.__add__(-other)
 
     def __rsub__(self, other):
-        if isinstance(other, (float, int)):
-            data = other - self._data
-            return Quantity(data, self._unit)
-        elif isinstance(other, Quantity):
-            if self._unit.dimension != other._unit.dimension:
-                raise ArithmeticError(
-                    "Unit dimensions must match for Quantity subtraction.")
-            data = other.to(self._unit) - self._data
-            return Quantity(data, self._unit)
-        else:
-            return NotImplemented
+        return -self.__sub__(other)
 
     def __mul__(self, other):
         if isinstance(other, (float, int)):
@@ -124,19 +94,7 @@ class Quantity:
             return NotImplemented
 
     def __rmul__(self, other):
-        if isinstance(other, (float, int)):
-            data = self._data * other
-            return Quantity(data, self._unit)
-        elif isinstance(other, Quantity):
-            if self._unit.dimension == other._unit.dimension:
-                data = self._data * other.to(self._unit)
-                unit = self._unit ** 2
-            else:
-                data = self._data * other._data
-                unit = self._unit * other._unit
-            return Quantity(data, unit)
-        else:
-            return NotImplemented
+        return self.__mul__(other)
 
     def __truediv__(self, other):
         if isinstance(other, (float, int)):
@@ -179,13 +137,7 @@ class Quantity:
             return NotImplemented
 
     def __ne__(self, other):
-        if isinstance(other, Quantity):
-            if self._unit.dimension != other._unit.dimension:
-                raise ArithmeticError(
-                    "Unit dimensions must match for comparison.")
-            return self._data != other.to(self._unit)
-        else:
-            return NotImplemented
+        return not self.__eq__(other)
 
     def __lt__(self, other):
         if isinstance(other, Quantity):
@@ -197,13 +149,7 @@ class Quantity:
             return NotImplemented
 
     def __le__(self, other):
-        if isinstance(other, Quantity):
-            if self._unit.dimension != other._unit.dimension:
-                raise ArithmeticError(
-                    "Unit dimensions must match for comparison.")
-            return self._data <= other.to(self._unit)
-        else:
-            return NotImplemented
+        return self.__eq__(other) or self.__lt__(other)
 
     def __gt__(self, other):
         if isinstance(other, Quantity):
@@ -215,13 +161,7 @@ class Quantity:
             return NotImplemented
 
     def __ge__(self, other):
-        if isinstance(other, Quantity):
-            if self._unit.dimension != other._unit.dimension:
-                raise ArithmeticError(
-                    "Unit dimensions must match for comparison.")
-            return self._data >= other.to(self._unit)
-        else:
-            return NotImplemented
+        return self.__eq__(other) or self.__gt__(other)
 
     @property
     def data(self):
@@ -230,6 +170,10 @@ class Quantity:
     @property
     def unit(self):
         return self._unit
+
+    @property
+    def dimension(self):
+        return self._unit.dimension
 
     def to(self, new_unit):
         """Return the Quantity data in the new unit.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -80,3 +80,4 @@ autodoc_default_options = {
 
 # Type hinting for autodoc.
 autodoc_typehints = 'description'
+autodoc_typehints_format = 'short'

--- a/docs/source/modules/units.rst
+++ b/docs/source/modules/units.rst
@@ -21,6 +21,9 @@ Initialized units are accessed from the units module which can be imported by th
 
    from celest import units as u
 
+Primary Units
+^^^^^^^^^^^^^
+
 Primary units can then be accessed using a dot notation.
 
 .. code-block:: python
@@ -93,12 +96,30 @@ The following table lists all primary units, their code call sign, and their mea
      - `u.hourangle`
      - Angle
 
+Primary units are instances of the :class:`Unit` class and can be used to create new units.
+
+.. autoclass:: celest.units.core.Unit
+   :members:
+   :inherited-members:
+
+Compound Units
+^^^^^^^^^^^^^^
+
 Primary units can be combined with others through multiplication or division to create compound units.
 
 .. code-block:: python
 
    velocity_unit = u.m / u.s  # Meter per second.
    acceleration_unit = u.m / u.s ^ 2  # Meter per second squared.
+
+Compound units are instances of the :class:`CompoundUnit` class and can be used to create new units.
+
+.. autoclass:: celest.units.core.CompoundUnit
+   :members:
+   :inherited-members:
+
+Passing Units into Celest
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Units are typically passed into Celest's class constructors, methods, and functions as a parameter to specify the data
 measure. Internally, the data and units get stored together in a :class:`Quantity` object that may be returned from a

--- a/tests/test_coordinates/test_astronomical_quantities.py
+++ b/tests/test_coordinates/test_astronomical_quantities.py
@@ -162,7 +162,7 @@ class TestAstronomicalQuantities(TestCase):
         julian = Quantity(2455368.75, u.jd2000)
 
         expected_equation_of_time = -0.42658
-        actual_equation_of_time = equation_of_time(julian).to(u.deg).data
+        actual_equation_of_time = equation_of_time(julian).to(u.deg)
 
         self.assertAlmostEqual(expected_equation_of_time,
                                actual_equation_of_time, delta=0.04)

--- a/tests/test_coordinates/test_ground_location.py
+++ b/tests/test_coordinates/test_ground_location.py
@@ -46,16 +46,17 @@ class TestGroundLocation(TestCase):
         self.assertEqual(self.location.height.data, self.height)
 
     def test_radius(self):
-        self.assertAlmostEqual(self.location.radius.data, 6871.555, delta=0.01)
+        self.assertAlmostEqual(self.location.radius.to(u.km), 6871.555,
+                               delta=0.01)
 
     def test_itrs_x(self):
-        self.assertAlmostEqual(self.location.itrs_x.to(u.km).data, 6343.8162,
+        self.assertAlmostEqual(self.location.itrs_x.to(u.km), 6343.8162,
                                delta=0.005)
 
     def test_itrs_y(self):
-        self.assertAlmostEqual(self.location.itrs_y.to(u.km).data, -2640.8722,
+        self.assertAlmostEqual(self.location.itrs_y.to(u.km), -2640.8722,
                                delta=0.005)
 
     def test_itrs_z(self):
-        self.assertAlmostEqual(self.location.itrs_z.to(u.km).data, -11.2554,
+        self.assertAlmostEqual(self.location.itrs_z.to(u.km), -11.2554,
                                delta=0.005)

--- a/tests/test_coordinates/test_transforms.py
+++ b/tests/test_coordinates/test_transforms.py
@@ -115,9 +115,9 @@ class TestCoordinateTransformations(TestCase):
         from astropy.time import Time
 
         location = EarthLocation.from_geodetic(
-            self.location.longitude.to(u.deg).data * astropy_u.deg,
-            self.location.latitude.to(u.deg).data * astropy_u.deg,
-            self.location.height.to(u.km).data * astropy_u.km
+            self.location.longitude.to(u.deg) * astropy_u.deg,
+            self.location.latitude.to(u.deg) * astropy_u.deg,
+            self.location.height.to(u.km) * astropy_u.km
         )
 
         times = Time(self.itrs.time.data, format="jd")

--- a/tests/test_encounter/test_window_generator.py
+++ b/tests/test_encounter/test_window_generator.py
@@ -68,11 +68,12 @@ class TestGenerateVTW(TestCase):
             vis_threshold,
             Lighting.DAYTIME
         )
-        satellite_elevation = self._get_satellite_elevation().to(u.deg).data
-        sun_elevation = self._get_sun_elevation().to(u.deg).data
+        satellite_elevation = self._get_satellite_elevation().to(u.deg)
+        sun_elevation = self._get_sun_elevation().to(u.deg)
 
         for window in windows:
-            rise_time, set_time = window.rise_time.data, window.set_time.data
+            rise_time = window.rise_time.to(u.jd2000)
+            set_time = window.set_time.to(u.jd2000)
             window_indices = np.where((rise_time <= self.julian) &
                                       (self.julian <= set_time))[0]
 
@@ -98,11 +99,12 @@ class TestGenerateVTW(TestCase):
             vis_threshold,
             Lighting.NIGHTTIME
         )
-        satellite_elevation = self._get_satellite_elevation().to(u.deg).data
-        sun_elevation = self._get_sun_elevation().to(u.deg).data
+        satellite_elevation = self._get_satellite_elevation().to(u.deg)
+        sun_elevation = self._get_sun_elevation().to(u.deg)
 
         for window in windows:
-            rise_time, set_time = window.rise_time.data, window.set_time.data
+            rise_time = window.rise_time.to(u.jd2000)
+            set_time = window.set_time.to(u.jd2000)
             window_indices = np.where((rise_time <= self.julian) &
                                       (self.julian <= set_time))[0]
 
@@ -114,7 +116,7 @@ class TestGenerateVTW(TestCase):
     def test_get_night_constraint_indices(self):
         indices = _get_night_constraint_indices(self.julian, self.location)
         sun_elevation = self._get_sun_elevation()
-        self.assertTrue(np.alltrue(sun_elevation.to(u.deg).data[indices] < 0))
+        self.assertTrue(np.alltrue(sun_elevation.to(u.deg)[indices] < 0))
 
     def test_get_sun_gcrs(self):
         from astropy.coordinates import get_body
@@ -139,4 +141,4 @@ class TestGenerateVTW(TestCase):
     def test_get_day_constraint_indices(self):
         sun_elevation = self._get_sun_elevation()
         indices = _get_day_constraint_indices(self.julian, self.location)
-        self.assertTrue(np.alltrue(sun_elevation.to(u.deg).data[indices] > 0))
+        self.assertTrue(np.alltrue(sun_elevation.to(u.deg)[indices] > 0))

--- a/tests/test_schedule/test_insertion_operators.py
+++ b/tests/test_schedule/test_insertion_operators.py
@@ -106,7 +106,7 @@ class TestInsertionOperators(TestCase):
     def _schedule_first_request(self):
         rise_time = self.request_handler[0][10][0].rise_time
         set_time = self.request_handler[0][10][0].set_time
-        duration = Quantity(86400 * (set_time.to(u.jd2000).data - rise_time.to(u.jd2000).data), u.s)
+        duration = Quantity(86400 * (set_time.to(u.jd2000) - rise_time.to(u.jd2000)), u.s)
 
         self.request_handler.schedule_request(0, 0, rise_time, duration)
 

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -16,7 +16,7 @@ class TestTime(TestCase):
         self.astropy_time = time.Time(self.julian, format="jd")
 
     def test_julian(self):
-        actual_julian = Time(julian=self.julian).julian.data
+        actual_julian = Time(self.julian).julian.to(u.jd2000)
         self.assertTrue(np.array_equal(self.julian, actual_julian))
 
     def test_true_solar_time_for_validation(self):
@@ -40,7 +40,7 @@ class TestTime(TestCase):
         longitude = [-105, -118.24, 147.46]
 
         expected_true_solar_time = np.array([23.0715, 0.378059, 10.76556])
-        actual_true_solar_time = Time(julian).true_solar_time(longitude).to(u.hourangle).data
+        actual_true_solar_time = Time(julian).true_solar_time(longitude).to(u.hourangle)
 
         self.assertTrue(np.allclose(expected_true_solar_time,
                                     actual_true_solar_time, atol=0.11))
@@ -62,7 +62,7 @@ class TestTime(TestCase):
         longitude = 147.46
 
         expected_mean_solar_time = np.array([10.83056])
-        actual_mean_solar_time = Time(julian).mean_solar_time(longitude).to(u.hourangle).data
+        actual_mean_solar_time = Time(julian).mean_solar_time(longitude).to(u.hourangle)
 
         self.assertTrue(np.allclose(expected_mean_solar_time,
                                     actual_mean_solar_time, atol=0.001))
@@ -85,7 +85,7 @@ class TestTime(TestCase):
         longitude = [-105, -118.24, 147.46]
 
         expected_true_hour_angle = np.array([166.0734, 185.671, 341.53]) / 15 % 24
-        actual_true_hour_angle = Time(julian).true_hour_angle(longitude).to(u.hourangle).data
+        actual_true_hour_angle = Time(julian).true_hour_angle(longitude).to(u.hourangle)
 
         self.assertTrue(np.allclose(expected_true_hour_angle,
                                     actual_true_hour_angle, atol=1.51))
@@ -95,7 +95,7 @@ class TestTime(TestCase):
         longitude = 147.46
 
         true_mean_hour_angle = np.array([342.4584]) / 15 % 24
-        test_mean_hour_angle = Time(julian).mean_hour_angle(longitude).to(u.hourangle).data
+        test_mean_hour_angle = Time(julian).mean_hour_angle(longitude).to(u.hourangle)
 
         self.assertTrue(np.allclose(true_mean_hour_angle, test_mean_hour_angle,
                         atol=0.01))
@@ -105,12 +105,12 @@ class TestTime(TestCase):
 
         expected_ut1 = self.astropy_time.to_value("decimalyear") % 1
         expected_ut1 = (expected_ut1 * 365 * 24) % 24 + ut1_utc_diff
-        actual_ut1 = Time(self.julian).ut1().to(u.hourangle).data
+        actual_ut1 = Time(self.julian).ut1().to(u.hourangle)
 
         self.assertTrue(np.allclose(expected_ut1, actual_ut1, atol=0.001))
 
     def test_datetime(self):
-        test_datetime = Time(julian=self.julian).datetime()
+        test_datetime = Time(self.julian).datetime()
 
         for julian, test_datetime_instace in zip(self.julian, test_datetime):
             true_datetime_instance = jd.from_jd(julian)
@@ -129,28 +129,28 @@ class TestTime(TestCase):
     def test_gmst(self):
         expected_gmst = self.astropy_time.sidereal_time("mean", "greenwich")
         expected_gmst = coordinates.Angle(expected_gmst).hour
-        actual_gmst = Time(self.julian).gmst().to(u.hourangle).data
+        actual_gmst = Time(self.julian).gmst().to(u.hourangle)
 
         self.assertTrue(np.allclose(expected_gmst, actual_gmst, atol=0.0001))
 
     def test_lmst(self):
         expected_lmst = self.astropy_time.sidereal_time("mean", longitude="150")
         expected_lmst = coordinates.Angle(expected_lmst).hour
-        actual_lmst = Time(self.julian).lmst(150).to(u.hourangle).data
+        actual_lmst = Time(self.julian).lmst(150).to(u.hourangle)
 
         self.assertTrue(np.allclose(expected_lmst, actual_lmst, atol=0.1))
 
     def test_gast(self):
         expected_gast = self.astropy_time.sidereal_time("apparent", "greenwich")
         expected_gast = coordinates.Angle(expected_gast).hour
-        actual_gast = Time(self.julian).gast().to(u.hourangle).data
+        actual_gast = Time(self.julian).gast().to(u.hourangle)
 
         self.assertTrue(np.allclose(expected_gast, actual_gast, atol=0.0001))
 
     def test_last(self):
         expected_last = self.astropy_time.sidereal_time("apparent", longitude="150")
         expected_last = coordinates.Angle(expected_last).hour
-        actual_last = Time(self.julian).last(150).to(u.hourangle).data
+        actual_last = Time(self.julian).last(150).to(u.hourangle)
         
         self.assertTrue(np.allclose(expected_last, actual_last, atol=0.1))
 

--- a/tests/test_units/test_quantity.py
+++ b/tests/test_units/test_quantity.py
@@ -277,7 +277,7 @@ class TestQuantity(TestCase):
         self.assertTrue(self.simple_quantity <= self.simple_quantity)
 
     def test_le_when_greater_with_same_dimensions(self):
-        self.assertFalse((self.simple_quantity + 1) <= self.simple_quantity)
+        self.assertFalse((self.simple_quantity + self.comparison_offset) <= self.simple_quantity)
 
     def test_le_with_different_dimensions_raises_arithmetic_error(self):
         self.assertRaises(ArithmeticError, self.simple_quantity.__le__,
@@ -296,7 +296,7 @@ class TestQuantity(TestCase):
         self.assertFalse(self.simple_quantity <= similar_quantity)
 
     def test_gt_when_greater_with_same_dimensions(self):
-        self.assertTrue((self.simple_quantity + 1) > self.simple_quantity)
+        self.assertTrue((self.simple_quantity + self.comparison_offset) > self.simple_quantity)
 
     def test_gt_when_less_with_same_dimensions(self):
         self.assertFalse(self.simple_quantity > (self.simple_quantity + 1))
@@ -314,7 +314,7 @@ class TestQuantity(TestCase):
         self.assertFalse(self.simple_quantity > similar_quantity)
 
     def test_ge_when_greater_with_same_dimensions(self):
-        self.assertTrue((self.simple_quantity + 1) >= self.simple_quantity)
+        self.assertTrue((self.simple_quantity + self.comparison_offset) >= self.simple_quantity)
 
     def test_ge_when_equal_with_same_dimensions(self):
         self.assertTrue(self.simple_quantity >= self.simple_quantity)

--- a/tests/test_units/test_quantity.py
+++ b/tests/test_units/test_quantity.py
@@ -223,29 +223,24 @@ class TestQuantity(TestCase):
                           self.compound_quantity)
 
     def test_to_with_same_dimension(self):
-        simple_quantity_in_km = self.simple_quantity.to(u.km)
-        self.assertEqual(0.005, simple_quantity_in_km.data)
-        self.assertEqual(u.km, simple_quantity_in_km.unit)
+        self.assertEqual(0.005, self.simple_quantity.to(u.km))
 
     def test_to_with_different_dimension_raises_value_error(self):
         self.assertRaises(ValueError, self.simple_quantity.to, u.s)
 
-    def test_get_unit(self):
-        self.assertEqual(self.simple_unit, self.simple_quantity.get_unit())
-
     def test_convert_to_same_dimension(self):
-        self.simple_quantity.convert_to(u.km)
-        self.assertEqual(0.005, self.simple_quantity.data)
-        self.assertEqual(u.km, self.simple_quantity.unit)
+        new_quantity = self.simple_quantity._convert_to(u.km)
+        self.assertEqual(0.005, new_quantity.data)
+        self.assertEqual(u.km, new_quantity.unit)
 
     def test_convert_to_with_compound_unit(self):
         new_compound_unit = u.km / u.hr
-        self.compound_quantity.convert_to(new_compound_unit)
-        self.assertEqual(18, self.compound_quantity.data)
-        self.assertEqual(new_compound_unit, self.compound_quantity.unit)
+        new_quantity = self.compound_quantity._convert_to(new_compound_unit)
+        self.assertEqual(18, new_quantity.data)
+        self.assertEqual(new_compound_unit, new_quantity.unit)
 
     def test_convert_to_different_dimension_raises_ValueError(self):
-        self.assertRaises(ValueError, self.simple_quantity.convert_to, u.s)
+        self.assertRaises(ValueError, self.simple_quantity._convert_to, u.s)
 
     def test_convert_to_with_compound_unit_with_different_dimensions(self):
-        self.assertRaises(ValueError, self.compound_quantity.convert_to, u.s)
+        self.assertRaises(ValueError, self.compound_quantity._convert_to, u.s)

--- a/tests/test_units/test_quantity.py
+++ b/tests/test_units/test_quantity.py
@@ -17,6 +17,8 @@ class TestQuantity(TestCase):
         self.compound_unit = u.m / u.s
         self.compound_quantity = Quantity(self.data, self.compound_unit)
 
+        self.comparison_offset = 1
+
     def test_initialization(self):
         self.assertEqual(self.data, self.simple_quantity.data)
         self.assertEqual(self.simple_unit, self.simple_quantity.unit)
@@ -48,6 +50,13 @@ class TestQuantity(TestCase):
         self.assertRaises(ArithmeticError, self.simple_quantity.__add__,
                           self.compound_quantity)
 
+    def test_add_quantity_of_same_dimension_but_different_unit(self):
+        similar_data = 0.1
+        similar_quantity = Quantity(similar_data, u.km)
+        result = self.simple_quantity.__add__(similar_quantity)
+        self.assertEqual(self.data + similar_data * 1000, result.data)
+        self.assertEqual(self.simple_unit, result.unit)
+
     def test_radd_scalar(self):
         result = self.simple_quantity.__radd__(self.data)
         self.assertEqual(self.data + self.data, result.data)
@@ -61,6 +70,13 @@ class TestQuantity(TestCase):
     def test_radd_quantity_of_different_dimensions_raises_error(self):
         self.assertRaises(ArithmeticError, self.simple_quantity.__radd__,
                           self.compound_quantity)
+
+    def test_radd_quantity_of_same_dimension_but_different_unit(self):
+        similar_data = 0.1
+        similar_quantity = Quantity(similar_data, u.km)
+        result = self.simple_quantity.__radd__(similar_quantity)
+        self.assertEqual(self.data + similar_data * 1000, result.data)
+        self.assertEqual(self.simple_unit, result.unit)
 
     def test_sub_scalar(self):
         result = self.simple_quantity - 7
@@ -76,6 +92,13 @@ class TestQuantity(TestCase):
         self.assertRaises(ArithmeticError, self.simple_quantity.__sub__,
                           self.compound_quantity)
 
+    def test_sub_quantity_of_same_dimension_but_different_unit(self):
+        similar_data = 0.1
+        similar_quantity = Quantity(similar_data, u.km)
+        result = self.simple_quantity.__sub__(similar_quantity)
+        self.assertEqual(self.data - similar_data * 1000, result.data)
+        self.assertEqual(self.simple_unit, result.unit)
+
     def test_rsub_scalar(self):
         result = 7 - self.simple_quantity
         self.assertEqual(7 - self.data, result.data)
@@ -89,6 +112,13 @@ class TestQuantity(TestCase):
     def test_rsub_quantity_of_different_dimensions_raises_error(self):
         self.assertRaises(ArithmeticError, self.simple_quantity.__rsub__,
                           self.compound_quantity)
+
+    def test_rsub_quantity_of_same_dimension_but_different_unit(self):
+        similar_data = 0.1
+        similar_quantity = Quantity(similar_data, u.km)
+        result = self.simple_quantity.__rsub__(similar_quantity)
+        self.assertEqual(similar_data * 1000 - self.data, result.data)
+        self.assertEqual(self.simple_unit, result.unit)
 
     def test_mul_scalar(self):
         result = self.simple_quantity.__mul__(self.data)
@@ -106,6 +136,13 @@ class TestQuantity(TestCase):
         self.assertEqual(repr(self.simple_unit * self.compound_unit),
                          repr(result.unit))
 
+    def test_mul_quantity_of_same_dimension_but_different_unit(self):
+        similar_data = 0.1
+        similar_quantity = Quantity(similar_data, u.km)
+        result = self.simple_quantity.__mul__(similar_quantity)
+        self.assertEqual(self.data * similar_data * 1000, result.data)
+        self.assertEqual(repr(self.simple_unit ** 2), repr(result.unit))
+
     def test_rmul_scalar(self):
         result = self.simple_quantity.__rmul__(self.data)
         self.assertEqual(self.data * self.data, result.data)
@@ -122,6 +159,13 @@ class TestQuantity(TestCase):
         self.assertEqual(repr(self.simple_unit * self.compound_unit),
                          repr(result.unit))
 
+    def test_rmul_quantity_of_same_dimension_but_different_unit(self):
+        similar_data = 0.1
+        similar_quantity = Quantity(similar_data, u.km)
+        result = self.simple_quantity.__rmul__(similar_quantity)
+        self.assertEqual(self.data * similar_data * 1000, result.data)
+        self.assertEqual(repr(self.simple_unit ** 2), repr(result.unit))
+
     def test_truediv_scaler(self):
         result = self.simple_quantity.__truediv__(2 * self.data)
         self.assertEqual(0.5, result.data)
@@ -137,6 +181,14 @@ class TestQuantity(TestCase):
         result = self.simple_quantity.__truediv__(self.compound_quantity)
         self.assertEqual(1, result.data)
         self.assertEqual(repr(self.simple_unit / self.compound_unit),
+                         repr(result.unit))
+
+    def test_truediv_quantity_of_same_dimension_but_different_unit(self):
+        similar_data = 0.1
+        similar_quantity = Quantity(similar_data, u.km)
+        result = self.simple_quantity.__truediv__(similar_quantity)
+        self.assertEqual(self.data / (similar_data * 1000), result.data)
+        self.assertEqual(repr(self.simple_unit / self.simple_unit),
                          repr(result.unit))
 
     def test_rtruediv_scaler(self):
@@ -156,6 +208,14 @@ class TestQuantity(TestCase):
         self.assertEqual(repr(self.compound_unit / self.simple_unit),
                          repr(result.unit))
 
+    def test_rtruediv_quantity_of_same_dimension_but_different_unit(self):
+        similar_data = 0.1
+        similar_quantity = Quantity(similar_data, u.km)
+        result = self.simple_quantity.__rtruediv__(similar_quantity)
+        self.assertEqual(similar_data * 1000 / self.data, result.data)
+        self.assertEqual(repr(self.simple_unit / self.simple_unit),
+                         repr(result.unit))
+
     def test_eq_when_equal_with_same_dimensions(self):
         self.assertTrue(self.simple_quantity == self.simple_quantity)
 
@@ -165,6 +225,14 @@ class TestQuantity(TestCase):
     def test_eq_with_different_dimensions_raises_arithmetic_error(self):
         self.assertRaises(ArithmeticError, self.simple_quantity.__eq__,
                           self.compound_quantity)
+
+    def test_eq_when_equal_with_quantity_of_same_dimension_but_different_unit(self):
+        similar_quantity = Quantity(self.data / 1000, u.km)
+        self.assertTrue(self.simple_quantity == similar_quantity)
+
+    def test_eq_when_not_equal_with_quantity_of_same_dimension_but_different_unit(self):
+        similar_quantity = Quantity((self.data + self.comparison_offset) / 1000, u.km)
+        self.assertFalse(self.simple_quantity == similar_quantity)
 
     def test_neq_when_not_equal_with_same_dimensions(self):
         self.assertTrue(self.simple_quantity != (self.simple_quantity + 1))
@@ -176,6 +244,14 @@ class TestQuantity(TestCase):
         self.assertRaises(ArithmeticError, self.simple_quantity.__ne__,
                           self.compound_quantity)
 
+    def test_neq_when_equal_with_quantity_of_same_dimension_but_different_unit(self):
+        similar_quantity = Quantity(self.data / 1000, u.km)
+        self.assertFalse(self.simple_quantity != similar_quantity)
+
+    def test_neq_when_not_equal_with_quantity_of_same_dimension_but_different_unit(self):
+        similar_quantity = Quantity((self.data + self.comparison_offset) / 1000, u.km)
+        self.assertTrue(self.simple_quantity != similar_quantity)
+
     def test_lt_when_less_than_with_same_dimensions(self):
         self.assertTrue(self.simple_quantity < (self.simple_quantity + 1))
 
@@ -186,18 +262,38 @@ class TestQuantity(TestCase):
         self.assertRaises(ArithmeticError, self.simple_quantity.__lt__,
                           self.compound_quantity)
 
-    def test_le_when_less_than_with_same_dimensions(self):
+    def test_lt_when_less_than_quantity_of_same_dimension_but_different_unit(self):
+        similar_quantity = Quantity(self.data / 1000 + self.comparison_offset, u.km)
+        self.assertTrue(self.simple_quantity < similar_quantity)
+
+    def test_lt_when_greater_than_quantity_of_same_dimension_but_different_unit(self):
+        similar_quantity = Quantity(self.data / 1000 - self.comparison_offset, u.km)
+        self.assertFalse(self.simple_quantity < similar_quantity)
+
+    def test_le_when_less_with_same_dimensions(self):
         self.assertTrue(self.simple_quantity <= (self.simple_quantity + 1))
 
-    def test_le_when_equal_with_same_dimensions(self):
+    def test_le_when_equal_same_dimensions(self):
         self.assertTrue(self.simple_quantity <= self.simple_quantity)
 
-    def test_le_when_greater_than_with_same_dimensions(self):
+    def test_le_when_greater_with_same_dimensions(self):
         self.assertFalse((self.simple_quantity + 1) <= self.simple_quantity)
 
     def test_le_with_different_dimensions_raises_arithmetic_error(self):
         self.assertRaises(ArithmeticError, self.simple_quantity.__le__,
                           self.compound_quantity)
+
+    def test_le_when_less_with_quantity_of_same_dimension_but_different_unit(self):
+        similar_quantity = Quantity(self.data / 1000 + self.comparison_offset, u.km)
+        self.assertTrue(self.simple_quantity <= similar_quantity)
+
+    def test_le_when_equal_with_quantity_of_same_dimension_but_different_unit(self):
+        similar_quantity = Quantity(self.data / 1000, u.km)
+        self.assertTrue(self.simple_quantity <= similar_quantity)
+
+    def test_le_when_greater_with_quantity_of_same_dimension_but_different_unit(self):
+        similar_quantity = Quantity(self.data / 1000 - self.comparison_offset, u.km)
+        self.assertFalse(self.simple_quantity <= similar_quantity)
 
     def test_gt_when_greater_with_same_dimensions(self):
         self.assertTrue((self.simple_quantity + 1) > self.simple_quantity)
@@ -209,18 +305,38 @@ class TestQuantity(TestCase):
         self.assertRaises(ArithmeticError, self.simple_quantity.__gt__,
                           self.compound_quantity)
 
-    def test_ge_when_greater_than_with_same_dimensions(self):
+    def test_gt_when_greater_with_quantity_of_same_dimension_but_different_unit(self):
+        similar_quantity = Quantity(self.data / 1000 - self.comparison_offset, u.km)
+        self.assertTrue(self.simple_quantity > similar_quantity)
+
+    def test_gt_when_less_with_quantity_of_same_dimension_but_different_unit(self):
+        similar_quantity = Quantity(self.data / 1000 + self.comparison_offset, u.km)
+        self.assertFalse(self.simple_quantity > similar_quantity)
+
+    def test_ge_when_greater_with_same_dimensions(self):
         self.assertTrue((self.simple_quantity + 1) >= self.simple_quantity)
 
     def test_ge_when_equal_with_same_dimensions(self):
         self.assertTrue(self.simple_quantity >= self.simple_quantity)
 
-    def test_ge_when_less_than_with_same_dimensions(self):
+    def test_ge_when_less_with_same_dimensions(self):
         self.assertFalse(self.simple_quantity >= (self.simple_quantity + 1))
 
     def test_ge_with_different_dimensions_raises_arithmetic_error(self):
         self.assertRaises(ArithmeticError, self.simple_quantity.__ge__,
                           self.compound_quantity)
+
+    def test_ge_when_greater_with_quantity_of_same_dimension_but_different_unit(self):
+        similar_quantity = Quantity(self.data / 1000 - self.comparison_offset, u.km)
+        self.assertTrue(self.simple_quantity >= similar_quantity)
+
+    def test_ge_when_equal_with_quantity_of_same_dimension_but_different_unit(self):
+        similar_quantity = Quantity(self.data / 1000, u.km)
+        self.assertTrue(self.simple_quantity >= similar_quantity)
+
+    def test_ge_when_less_with_quantity_of_same_dimension_but_different_unit(self):
+        similar_quantity = Quantity(self.data / 1000 + self.comparison_offset, u.km)
+        self.assertFalse(self.simple_quantity >= similar_quantity)
 
     def test_to_with_same_dimension(self):
         self.assertEqual(0.005, self.simple_quantity.to(u.km))

--- a/tests/test_units/test_quantity.py
+++ b/tests/test_units/test_quantity.py
@@ -338,6 +338,16 @@ class TestQuantity(TestCase):
         similar_quantity = Quantity(self.data / 1000 + self.comparison_offset, u.km)
         self.assertFalse(self.simple_quantity >= similar_quantity)
 
+    def test_data_property(self):
+        self.assertEqual(self.simple_quantity.data, self.data)
+
+    def test_unit_property(self):
+        self.assertEqual(self.simple_quantity.unit, self.simple_unit)
+
+    def test_dimension_property(self):
+        self.assertEqual(self.simple_quantity.dimension,
+                         self.simple_unit.dimension)
+
     def test_to_with_same_dimension(self):
         self.assertEqual(0.005, self.simple_quantity.to(u.km))
 


### PR DESCRIPTION
This PR contains refactoring of the `Quantity` class to improve usability. Changes include:
* Refactor the `Quantity.to(new_unit)` method to return the data in the `new_unit`.  This change coupled with the removal of the `Quantity.convert_to(new_unit)` method forces users not to assume the internal data representation and preventing errors associated with operations on different units.
* The `Quantity` arithmetic and comparison operations were made to work with units of different units of the same dimensions rather than just of the same unit. This provides greater flexibility and prevents clunky data accessing.
* Code simplifications from the above changes were made in conversion code.
* The arithmetic and comparison dunder methods of the `Quantity` class were refactored to remove duplicate code.
* `Unit` and `Quantity` documentation was updated.
